### PR TITLE
Allow Renovate bot to trigger Claude Code reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           use_sticky_comment: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'renovate'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Fixes the Claude Code action failure on Renovate PRs by adding Renovate to the allowed bots list.

## Problem
The Claude Code Review workflow was failing on PRs created by Renovate with:
```
Workflow initiated by non-human actor: renovate (type: Bot). 
Add bot to allowed_bots list or use '*' to allow all bots.
```

## Solution
Added `allowed_bots: 'renovate'` to the Claude Code action configuration in the workflow file.

## Test Plan
- Verify the Claude Code action runs successfully on the next Renovate PR
- Check that automated code reviews are posted as comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)