### PR TITLE
Skip claude-review CI when updating claude-code-action dependency

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: ${{ !contains(github.head_ref, 'anthropics-claude-code-action') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip the `claude-review` CI workflow when the PR branch name contains `anthropics-claude-code-action` (i.e., Renovate updates to the claude-code-action dependency)
- Removes commented-out author filtering boilerplate

## Test plan
- [ ] Verify existing PRs still trigger claude-review as expected
- [ ] Verify Renovate PRs updating claude-code-action skip the review

🤖 Generated with [Claude Code](https://claude.com/claude-code)