### PR TITLE
Fix shell issues from PR #1042 review

### DIFF
--- a/.github/upstream-migration-tracker/check-migrations.sh
+++ b/.github/upstream-migration-tracker/check-migrations.sh
@@ -128,8 +128,22 @@ if [[ -n "$existing_pr" ]]; then
   git commit -m "Update last known upstream migration to $newest_migration"
   git push origin "$PR_BRANCH"
 
-  # Append new rows to the PR body before the closing link line
-  updated_body="${existing_body//$'\n\n[View migrations'/$'\n'${new_rows}$'\n\n[View migrations'}"
+  # Extract existing table rows from the PR body and append new ones
+  existing_rows="$(echo "$existing_body" | sed -n '/^| \[/p')"
+  all_rows="${existing_rows}"$'\n'"${new_rows}"
+
+  updated_body="$(cat <<EOF
+## New Upstream Migrations
+
+The following database migrations have been added to [actualbudget/actual](https://github.com/actualbudget/actual) and may need corresponding changes in Aktual.
+
+| Migration | Type |
+|-----------|------|
+${all_rows}
+
+[View migrations directory](https://github.com/actualbudget/actual/tree/master/packages/loot-core/migrations)
+EOF
+)"
 
   gh pr edit "$pr_number" \
     --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,9 +76,9 @@ jobs:
         with:
           fetch-depth: 0
       - run: |
-          files=$(git diff --name-only --diff-filter=ACMR origin/main -- '*.sh')
-          if [[ -n "$files" ]]; then
-            shellcheck $files
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR origin/main -- '*.sh')
+          if [[ ${#files[@]} -gt 0 ]]; then
+            shellcheck "${files[@]}"
           fi
 
   gitleaks:


### PR DESCRIPTION
## Summary
- Use `mapfile` array for shellcheck file list to properly handle filenames with spaces (SC2086)
- Regenerate full PR body from scratch in migration tracker instead of fragile string substitution that could silently drop new migration rows

Addresses review comments from #1042.

## Test plan
- [ ] Verify shellcheck CI job still passes on PRs with shell changes
- [ ] Run `check-migrations.sh` with `DRY_RUN=1` to verify output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)