### PR TITLE
Tolerate ReportMeta deserialization failures

### DIFF
--- a/aktual-budget/navrail/ui/src/commonMain/kotlin/aktual/budget/navrail/ui/edit/EditNavGridScreen.kt
+++ b/aktual-budget/navrail/ui/src/commonMain/kotlin/aktual/budget/navrail/ui/edit/EditNavGridScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -212,11 +212,12 @@ private fun EditNavGridContent(
     modifier = modifier.fillMaxSize(),
     contentPadding = PaddingValues(8.dp),
   ) {
-    items(state.items, key = { it.name }) { tab ->
+    itemsIndexed(state.items, key = { _, tab -> tab.name }) { index, tab ->
       ReorderableItem(reorderState, key = tab.name) { isDragging ->
         // Even/odd items jiggle in opposite directions for a livelier "editable" feel; the
-        // actively-dragged item stops jiggling and lifts slightly instead
-        val rotation = if (isDragging) 0f else jiggle * if (tab.ordinal % 2 == 0) 1f else -1f
+        // actively-dragged item stops jiggling and lifts slightly instead. Use the visual grid
+        // index, not tab.ordinal, so the alternation tracks position after reordering
+        val rotation = if (isDragging) 0f else jiggle * if (index % 2 == 0) 1f else -1f
         val scale = if (isDragging) DRAG_SCALE else 1f
 
         // The item wraps its content, so center it within the wider grid cell

--- a/aktual-budget/reports/vm/src/commonMain/kotlin/aktual/budget/reports/vm/ReportMeta.kt
+++ b/aktual-budget/reports/vm/src/commonMain/kotlin/aktual/budget/reports/vm/ReportMeta.kt
@@ -8,10 +8,19 @@ import aktual.budget.model.WidgetType
 import alakazam.kotlin.SerializableByString
 import alakazam.kotlin.enumStringSerializer
 import androidx.compose.runtime.Immutable
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.YearMonth
+import kotlinx.datetime.yearMonth
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonObject
+import logcat.logcat
 
 // From packages/loot-core/src/types/models/dashboard.ts
 @Immutable
@@ -31,6 +40,17 @@ sealed interface ReportMeta {
       }
   }
 }
+
+// Sentinel for a widget whose stored metadata couldn't be deserialized — corrupt data, or an
+// upstream schema change we don't model yet. Surfaced instead of crashing the whole dashboard.
+// It's never persisted, so it's intentionally not @Serializable; we keep the raw json around so
+// the original row isn't lost.
+@Immutable
+data class UnsupportedReportMeta(
+  val type: WidgetType,
+  val raw: JsonObject,
+  val reason: String,
+) : ReportMeta
 
 @Immutable
 @Serializable
@@ -131,10 +151,39 @@ data class FormulaQuery(
 @Immutable
 @Serializable
 data class TimeFrame(
-  @SerialName("start") val start: YearMonth,
-  @SerialName("end") val end: YearMonth,
+  @SerialName("start") @Serializable(LenientYearMonthSerializer::class) val start: YearMonth,
+  @SerialName("end") @Serializable(LenientYearMonthSerializer::class) val end: YearMonth,
   @SerialName("mode") val mode: TimeFrameMode,
 )
+
+// Upstream persists TimeFrame start/end as plain date strings, which may be either a year-month
+// ("2011-10") or a full ISO date ("2011-10-05"). The default YearMonth serializer only accepts
+// the former and crashes on the latter, so parse leniently and normalise both down to a YearMonth.
+internal object LenientYearMonthSerializer : KSerializer<YearMonth> {
+  override val descriptor =
+    PrimitiveSerialDescriptor("aktual.LenientYearMonth", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: YearMonth) =
+    encoder.encodeString(value.toString())
+
+  override fun deserialize(decoder: Decoder): YearMonth {
+    val raw = decoder.decodeString()
+    return raw.toYearMonthOrNull()
+      ?: throw SerializationException("Can't parse '$raw' as a year-month or date")
+  }
+}
+
+private fun String.toYearMonthOrNull(): YearMonth? =
+  try {
+    YearMonth.parse(this)
+  } catch (_: IllegalArgumentException) {
+    try {
+      LocalDate.parse(this).yearMonth
+    } catch (e: IllegalArgumentException) {
+      logcat.e(e) { "Failed decoding $this as YearMonth or LocalDate" }
+      null
+    }
+  }
 
 @Serializable(TimeFrameMode.Serializer::class)
 enum class TimeFrameMode(override val value: String) : SerializableByString {

--- a/aktual-budget/reports/vm/src/commonMain/kotlin/aktual/budget/reports/vm/dashboard/ReportsDashboardViewModel.kt
+++ b/aktual-budget/reports/vm/src/commonMain/kotlin/aktual/budget/reports/vm/dashboard/ReportsDashboardViewModel.kt
@@ -4,6 +4,7 @@ import aktual.budget.db.Dashboard
 import aktual.budget.db.dao.CustomReportsDao
 import aktual.budget.db.dao.DashboardDao
 import aktual.budget.model.WidgetId
+import aktual.budget.model.WidgetType
 import aktual.budget.reports.vm.BudgetAnalysisReportMeta
 import aktual.budget.reports.vm.CalendarReportMeta
 import aktual.budget.reports.vm.CashFlowReportMeta
@@ -16,6 +17,7 @@ import aktual.budget.reports.vm.NetWorthReportMeta
 import aktual.budget.reports.vm.ReportMeta
 import aktual.budget.reports.vm.SpendingReportMeta
 import aktual.budget.reports.vm.SummaryReportMeta
+import aktual.budget.reports.vm.UnsupportedReportMeta
 import aktual.di.BudgetScope
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
@@ -33,8 +35,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
+import logcat.logcat
 
 @Stable
 @ViewModelKey
@@ -70,6 +74,7 @@ internal constructor(
       is CalendarReportMeta -> flowOf()
       is CashFlowReportMeta -> chartDataLoader.cashFlow(meta)
       is CustomReportMeta -> flowOf()
+      is UnsupportedReportMeta -> flowOf()
       is FormulaReportMeta -> flowOf()
       is MarkdownReportMeta -> flowOf()
       is NetWorthReportMeta -> flowOf()
@@ -86,9 +91,20 @@ internal constructor(
       height = widget.height?.toInt() ?: 0,
       x = widget.x?.toInt() ?: 0,
       y = widget.y?.toInt() ?: 0,
-      meta = Json.decodeFromJsonElement(ReportMeta.serializer(type), meta),
+      meta = decodeMeta(type, meta),
     )
   }
+
+  // Decoding can fail on corrupt data or an upstream schema we don't model yet. Rather than let a
+  // single bad widget take down the whole dashboard, fall back to an UnsupportedReportMeta
+  // sentinel.
+  private fun decodeMeta(type: WidgetType, meta: JsonObject): ReportMeta =
+    try {
+      Json.decodeFromJsonElement(ReportMeta.serializer(type), meta)
+    } catch (e: Exception) {
+      logcat.e(e) { "Failed to deserialize $type report meta: $meta" }
+      UnsupportedReportMeta(type, meta, reason = e.message ?: e.toString())
+    }
 
   @Suppress("BracesOnWhenStatements")
   private suspend fun ReportMeta.renamed(name: String): ReportMeta? =
@@ -104,6 +120,7 @@ internal constructor(
 
       // Not nameable
       is MarkdownReportMeta -> null
+      is UnsupportedReportMeta -> null
 
       // Named, but it's stored in a separate table
       is CustomReportMeta -> {

--- a/aktual-budget/reports/vm/src/commonTest/kotlin/aktual/budget/reports/vm/ReportMetaSerializationTest.kt
+++ b/aktual-budget/reports/vm/src/commonTest/kotlin/aktual/budget/reports/vm/ReportMetaSerializationTest.kt
@@ -1,0 +1,69 @@
+package aktual.budget.reports.vm
+
+import aktual.budget.model.ConditionOp
+import aktual.budget.model.WidgetType
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.datetime.Month.JULY
+import kotlinx.datetime.Month.OCTOBER
+import kotlinx.datetime.YearMonth
+import kotlinx.serialization.json.Json
+
+class ReportMetaSerializationTest {
+  private val json = Json
+
+  @Test
+  fun `TimeFrame parses a full ISO date by truncating to year-month`() {
+    // Regression: upstream stores start/end as full dates like "2011-10-05", which used to crash
+    // the dashboard because the field is typed as a YearMonth.
+    val decoded =
+      json.decodeFromString(
+        TimeFrame.serializer(),
+        """{"start":"2011-10-05","end":"2025-07-31","mode":"static"}""",
+      )
+
+    assertThat(decoded.start).isEqualTo(YearMonth(2011, OCTOBER))
+    assertThat(decoded.end).isEqualTo(YearMonth(2025, JULY))
+    assertThat(decoded.mode).isEqualTo(TimeFrameMode.Static)
+  }
+
+  @Test
+  fun `TimeFrame parses a plain year-month`() {
+    val decoded =
+      json.decodeFromString(
+        TimeFrame.serializer(),
+        """{"start":"2011-10","end":"2025-07","mode":"sliding-window"}""",
+      )
+
+    assertThat(decoded.start).isEqualTo(YearMonth(2011, OCTOBER))
+    assertThat(decoded.mode).isEqualTo(TimeFrameMode.SlidingWindow)
+  }
+
+  @Test
+  fun `FormulaReportMeta with a full-date query time frame decodes`() {
+    // Mirrors the exact shape from the original crash: a formula query whose nested timeFrame
+    // holds full dates.
+    val element =
+      json.parseToJsonElement(
+        """
+        {
+          "queries": {
+            "a": {
+              "conditions": [],
+              "conditionsOp": "and",
+              "timeFrame": {"start":"2011-10-05","end":"2025-07-31","mode":"static"}
+            }
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    val decoded = json.decodeFromJsonElement(ReportMeta.serializer(WidgetType.Formula), element)
+
+    val formula = decoded as FormulaReportMeta
+    assertThat(formula.queries.getValue("a").timeFrame?.start).isEqualTo(YearMonth(2011, OCTOBER))
+    assertThat(formula.queries.getValue("a").conditionsOp).isEqualTo(ConditionOp.And)
+  }
+}


### PR DESCRIPTION
## Problem

Opening the reports dashboard crashed when a widget's stored metadata couldn't be deserialized:

```
kotlinx.datetime.DateTimeFormatException: Text '2011-10-05' could not be parsed, unparsed text found at index 7
    at kotlinx.datetime.YearMonth$Companion.parse(...)
    at aktual.budget.reports.vm.TimeFrame$$serializer.deserialize(ReportMeta.kt:131)
    ...
    at aktual.budget.reports.vm.FormulaReportMeta$$serializer.deserialize(ReportMeta.kt:110)
```

`TimeFrame.start`/`end` are typed `YearMonth`, but upstream Actual persists them as plain date strings that may be a full ISO date (`2011-10-05`) rather than a year-month (`2011-10`). The default `YearMonth` serializer rejects the full-date form, and a single such widget took down the entire dashboard.

## Changes

- **`LenientYearMonthSerializer`** — `TimeFrame.start`/`end` now accept either a year-month or a full ISO date, normalising both down to a `YearMonth`. Fixes the specific crash.
- **`UnsupportedReportMeta` sentinel** — a new subtype of the `ReportMeta` sealed interface. Decoding now falls back to it on *any* deserialization failure (keeping the raw JSON + reason), so one corrupt or not-yet-modelled widget can no longer crash the whole dashboard. In the UI it renders as an empty card.

## Tests

Added `ReportMetaSerializationTest` covering the full-date `TimeFrame` regression, the plain year-month case, and a `FormulaReportMeta` with a nested full-date query time frame (the exact shape from the stack trace).