### PR TITLE
Fix flaky ServerUrlViewModelTest

### DIFF
--- a/aktual-account/vm/src/androidHostTest/kotlin/aktual/account/vm/ServerUrlViewModelTest.kt
+++ b/aktual-account/vm/src/androidHostTest/kotlin/aktual/account/vm/ServerUrlViewModelTest.kt
@@ -31,10 +31,13 @@ import io.ktor.http.HttpStatusCode
 import java.io.IOException
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -51,9 +54,11 @@ class ServerUrlViewModelTest {
   fun after() {
     mockEngine.close()
     appGraph.close()
+    Dispatchers.resetMain()
   }
 
   private suspend fun TestScope.before() {
+    Dispatchers.setMain(standardDispatcher)
     mockEngine = emptyMockEngine()
 
     val contexts = TestCoroutineContexts(standardDispatcher)


### PR DESCRIPTION
## Problem

`ServerUrlViewModelTest` was intermittently failing in CI — for example [run #27088095016](https://github.com/jonapoul/aktual/actions/runs/27088095016):

```
ServerUrlViewModelTest > Show error message if bootstrap request fails FAILED
    org.opentest4j.AssertionFailedError: expected to contain:<"SOMETHING BROKE"> but was:<"Failed: Unhandled http://website.com/account/needs-bootstrap">
        at aktual.account.vm.ServerUrlViewModelTest$Show error message if bootstrap request fails$1$1.invokeSuspend(ServerUrlViewModelTest.kt:187)
        at app//kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
        at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:35)
        at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:101)
        at app//kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:47)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.test.TestDispatcher.processEvent$kotlinx_coroutines_test(TestDispatcher.kt:24)
        at kotlinx.coroutines.test.TestCoroutineScheduler.tryRunNextTaskUnless$kotlinx_coroutines_test(TestCoroutineScheduler.kt:98)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$workRunner$1.invokeSuspend(TestBuilders.kt:326)
        at app//kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:256)
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:54)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlockingImpl(Builders.kt:30)
        at kotlinx.coroutines.BuildersKt.runBlockingImpl(Unknown Source)
        at kotlinx.coroutines.BuildersKt__Builders_concurrentKt.runBlockingK(Builders.concurrent.kt:172)
        at kotlinx.coroutines.BuildersKt.runBlockingK(Unknown Source)
        at kotlinx.coroutines.BuildersKt__Builders_concurrentKt.runBlockingK$default(Builders.concurrent.kt:157)
        at kotlinx.coroutines.BuildersKt.runBlockingK$default(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersJvmKt.createTestResult(TestBuildersJvm.kt:10)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:309)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:1)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:167)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:1)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0$default(TestBuilders.kt:159)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0$default(TestBuilders.kt:1)
        at aktual.account.vm.ServerUrlViewModelTest.Show error message if bootstrap request fails(ServerUrlViewModelTest.kt:170)
```

## Root cause

A **two-scheduler race over a shared single-handler mock queue**.

- `emptyMockEngine()` returns a ktor `MockEngine.Queue` with `reuseHandlers = false`: each enqueued handler is consumed by exactly one request, tracked by an `invocationCount` that `clear()` does **not** reset. Once requests outnumber handlers, ktor throws `IllegalStateException("Unhandled <url>")` — the message seen above.
- `onClickConfirm()` calls `runLevelController.onServerChosen(url)`, which initializes the `ServerChosenGraph` and starts two background `Initializable`s that hit the **same** mock engine: `ServerPinger` (`healthApi.getHealth()`) and `ServerVersionFetcher` (`baseApi.fetchInfo()`) — alongside the `accountApi.needsBootstrap()` the test actually asserts on. The test enqueues only **one** handler, so the requests race to consume it.
- The race was nondeterministic because `needsBootstrap()` runs in `viewModelScope` (`Dispatchers.Main.immediate`), and the test never substituted `Dispatchers.Main`. Under Robolectric the VM coroutine ran on the real main looper while the pingers ran on the test `standardDispatcher`. Usually `needsBootstrap` won (→ `"SOMETHING BROKE"`); occasionally a ping consumed the handler first, leaving `needsBootstrap` with `"Unhandled …/needs-bootstrap"`.

## Fix

Call `Dispatchers.setMain(standardDispatcher)` in `before()` and `Dispatchers.resetMain()` in `after()`, so everything runs on a single virtual scheduler. `needsBootstrap` (no delay) then deterministically beats the pinger (2s delay) to the single handler. This matches `LoginViewModelTest` in the same module, which already does this.

## Testing

`./gradlew :aktual-account:vm:testAndroidHostTest --tests "aktual.account.vm.ServerUrlViewModelTest"` — all 6 tests pass.
