### PR TITLE
Use SavedStateHandle to persist transient ViewModel state

### DIFF
--- a/aktual-about/vm/build.gradle.kts
+++ b/aktual-about/vm/build.gradle.kts
@@ -1,7 +1,10 @@
 import blueprint.core.commonMainDependencies
 import blueprint.core.commonTestDependencies
 
-plugins { id("aktual.module.viewmodel") }
+plugins {
+  id("aktual.module.viewmodel")
+  alias(libs.plugins.kotlin.serialization)
+}
 
 kotlin {
   commonMainDependencies {

--- a/aktual-about/vm/src/androidHostTest/kotlin/aktual/about/vm/AboutViewModelTest.kt
+++ b/aktual-about/vm/src/androidHostTest/kotlin/aktual/about/vm/AboutViewModelTest.kt
@@ -8,6 +8,7 @@ import aktual.core.model.UrlOpener
 import aktual.test.TestBuildConfig
 import aktual.test.TestInstant
 import aktual.test.assertThatNextEmissionIsEqualTo
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import io.mockk.coEvery
 import io.mockk.confirmVerified
@@ -37,6 +38,7 @@ class AboutViewModelTest {
 
     viewModel =
       AboutViewModel(
+        savedState = SavedStateHandle(),
         buildConfig = TestBuildConfig,
         githubRepository = repository,
         urlOpener = urlOpener,

--- a/aktual-about/vm/src/androidHostTest/kotlin/aktual/about/vm/LicensesViewModelTest.kt
+++ b/aktual-about/vm/src/androidHostTest/kotlin/aktual/about/vm/LicensesViewModelTest.kt
@@ -7,6 +7,7 @@ import aktual.about.data.LicensesLoadState
 import aktual.about.data.LicensesRepository
 import aktual.core.model.UrlOpener
 import aktual.test.assertThatNextEmissionIsEqualTo
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import io.mockk.coEvery
@@ -151,7 +152,12 @@ class LicensesViewModelTest {
   }
 
   private fun buildViewModel() {
-    viewModel = LicensesViewModel(licensesRepository = repository, urlOpener = urlOpener)
+    viewModel =
+      LicensesViewModel(
+        savedState = SavedStateHandle(),
+        licensesRepository = repository,
+        urlOpener = urlOpener,
+      )
   }
 
   private suspend fun TurbineTestContext<LicensesState>.assertLoaded(

--- a/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/AboutViewModel.kt
+++ b/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/AboutViewModel.kt
@@ -10,12 +10,22 @@ import aktual.di.AppScope
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.savedstate.SavedState
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
 import app.cash.molecule.RecompositionMode.Immediate
 import app.cash.molecule.launchMolecule
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.time.toJavaInstant
@@ -28,25 +38,53 @@ import kotlinx.coroutines.launch
 import logcat.logcat
 
 @Stable
-@ViewModelKey
-@ContributesIntoMap(AppScope::class)
+@AssistedInject
 class AboutViewModel(
+  @Assisted private val savedState: SavedStateHandle,
   private val buildConfig: BuildConfig,
   private val githubRepository: GithubRepository,
   private val urlOpener: UrlOpener,
   private val aktualVersionsStateHolder: AktualVersionsStateHolder,
 ) : ViewModel() {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(AboutViewModel::class)
+  @ContributesIntoMap(AppScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): AboutViewModel =
+      create(extras.createSavedStateHandle())
+
+    fun create(@Assisted savedState: SavedStateHandle): AboutViewModel
+  }
+
   val buildState: StateFlow<BuildState> =
     viewModelScope.launchMolecule(Immediate) {
       val versions by aktualVersionsStateHolder.collectAsState()
       buildState(versions)
     }
 
-  private val mutableCheckUpdatesState =
-    MutableStateFlow<CheckUpdatesState>(CheckUpdatesState.Inactive)
+  private val mutableCheckUpdatesState = MutableStateFlow(restoreCheckUpdatesState())
   val checkUpdatesState: StateFlow<CheckUpdatesState> = mutableCheckUpdatesState.asStateFlow()
 
   private var checkUpdatesJob: Job? = null
+
+  init {
+    savedState.setSavedStateProvider(KEY_CHECK_UPDATES) {
+      encodeToSavedState(mutableCheckUpdatesState.value)
+    }
+  }
+
+  private fun restoreCheckUpdatesState(): CheckUpdatesState {
+    val restored =
+      savedState.get<SavedState>(KEY_CHECK_UPDATES)?.let {
+        decodeFromSavedState<CheckUpdatesState>(it)
+      }
+
+    return when (restored) {
+      null -> CheckUpdatesState.Inactive
+      is CheckUpdatesState.Checking -> CheckUpdatesState.Inactive
+      else -> restored
+    }
+  }
 
   fun openRepo() {
     openUrl(url = buildConfig.repoUrl)
@@ -103,5 +141,9 @@ class AboutViewModel(
       buildDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(zonedDateTime),
       year = zonedDateTime.year,
     )
+  }
+
+  private companion object {
+    const val KEY_CHECK_UPDATES = "check_updates_state"
   }
 }

--- a/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/AboutViewModel.kt
+++ b/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/AboutViewModel.kt
@@ -82,7 +82,11 @@ class AboutViewModel(
     return when (restored) {
       null -> CheckUpdatesState.Inactive
       is CheckUpdatesState.Checking -> CheckUpdatesState.Inactive
-      else -> restored
+
+      CheckUpdatesState.Inactive,
+      CheckUpdatesState.NoUpdateFound,
+      is CheckUpdatesState.Failed,
+      is CheckUpdatesState.UpdateFound -> restored
     }
   }
 

--- a/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/CheckUpdatesState.kt
+++ b/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/CheckUpdatesState.kt
@@ -1,16 +1,18 @@
 package aktual.about.vm
 
 import androidx.compose.runtime.Immutable
+import kotlinx.serialization.Serializable
 
 @Immutable
+@Serializable
 sealed interface CheckUpdatesState {
-  data object Inactive : CheckUpdatesState
+  @Serializable data object Inactive : CheckUpdatesState
 
-  data object Checking : CheckUpdatesState
+  @Serializable data object Checking : CheckUpdatesState
 
-  data object NoUpdateFound : CheckUpdatesState
+  @Serializable data object NoUpdateFound : CheckUpdatesState
 
-  data class Failed(val cause: String) : CheckUpdatesState
+  @Serializable data class Failed(val cause: String) : CheckUpdatesState
 
-  data class UpdateFound(val version: String, val url: String) : CheckUpdatesState
+  @Serializable data class UpdateFound(val version: String, val url: String) : CheckUpdatesState
 }

--- a/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/LicensesViewModel.kt
+++ b/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/LicensesViewModel.kt
@@ -7,12 +7,19 @@ import aktual.di.AppScope
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import app.cash.molecule.RecompositionMode.Immediate
 import app.cash.molecule.launchMolecule
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,22 +28,32 @@ import kotlinx.coroutines.launch
 import logcat.logcat
 
 @Stable
-@ViewModelKey
-@ContributesIntoMap(AppScope::class)
-class LicensesViewModel
-internal constructor(
+@AssistedInject
+class LicensesViewModel(
+  @Assisted private val savedState: SavedStateHandle,
   private val licensesRepository: LicensesRepository,
   private val urlOpener: UrlOpener,
 ) : ViewModel() {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(LicensesViewModel::class)
+  @ContributesIntoMap(AppScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): LicensesViewModel =
+      create(extras.createSavedStateHandle())
+
+    fun create(@Assisted savedState: SavedStateHandle): LicensesViewModel
+  }
+
   private val mutableState = MutableStateFlow<LicensesState>(LicensesState.Loading)
-  private val mutableIsSearchActive = MutableStateFlow(value = false)
-  private val searchTerm = MutableStateFlow(value = "")
+
+  private val searchTerm = savedState.getStateFlow(KEY_SEARCH_TERM, "")
+  private val isSearchActive = savedState.getStateFlow(KEY_IS_SEARCH_ACTIVE, false)
 
   val licensesState: StateFlow<LicensesState> =
     viewModelScope.launchMolecule(Immediate) {
       val licensesState by mutableState.collectAsState()
       val searchTerm by searchTerm.collectAsState()
-      val isSearchActive by mutableIsSearchActive.collectAsState()
+      val isSearchActive by isSearchActive.collectAsState()
 
       when (val licenses = licensesState) {
         is LicensesState.Loaded -> licenses.filteredBy(searchTerm, isSearchActive)
@@ -80,17 +97,22 @@ internal constructor(
 
   fun openSearch() {
     logcat.d { "openSearch" }
-    mutableIsSearchActive.update { true }
+    savedState[KEY_IS_SEARCH_ACTIVE] = true
   }
 
   fun clearFilter() {
     logcat.d { "clearFilter" }
-    searchTerm.update { "" }
-    mutableIsSearchActive.update { false }
+    savedState[KEY_SEARCH_TERM] = ""
+    savedState[KEY_IS_SEARCH_ACTIVE] = false
   }
 
   fun setFilterText(text: String) {
     logcat.d { "setFilterText $text" }
-    searchTerm.update { text }
+    savedState[KEY_SEARCH_TERM] = text
+  }
+
+  private companion object {
+    const val KEY_SEARCH_TERM = "search_term"
+    const val KEY_IS_SEARCH_ACTIVE = "is_search_active"
   }
 }

--- a/aktual-budget/rules/vm/build.gradle.kts
+++ b/aktual-budget/rules/vm/build.gradle.kts
@@ -1,5 +1,8 @@
 import blueprint.core.commonMainDependencies
 
-plugins { id("aktual.module.viewmodel") }
+plugins {
+  id("aktual.module.viewmodel")
+  alias(libs.plugins.kotlin.serialization)
+}
 
 kotlin { commonMainDependencies { api(project(":aktual-budget:data:db")) } }

--- a/aktual-budget/rules/vm/src/commonMain/kotlin/aktual/budget/rules/vm/list/ListRulesViewModel.kt
+++ b/aktual-budget/rules/vm/src/commonMain/kotlin/aktual/budget/rules/vm/list/ListRulesViewModel.kt
@@ -26,36 +26,59 @@ import alakazam.kotlin.requireMessage
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.savedstate.SavedState
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
+import app.cash.molecule.RecompositionMode.Immediate
 import app.cash.molecule.launchMolecule
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 import logcat.logcat
 
 @Stable
-@ViewModelKey
-@ContributesIntoMap(BudgetScope::class)
+@AssistedInject
 class ListRulesViewModel(
+  @Assisted private val savedState: SavedStateHandle,
   private val rulesDao: RulesDao,
   private val syncController: BudgetSyncController,
   val nameFetcher: NameFetcher,
 ) : ViewModel() {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(ListRulesViewModel::class)
+  @ContributesIntoMap(BudgetScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): ListRulesViewModel =
+      create(extras.createSavedStateHandle())
+
+    fun create(@Assisted savedState: SavedStateHandle): ListRulesViewModel
+  }
+
   private val mutableRules = MutableStateFlow<ImmutableList<Rule>>(persistentListOf())
   private val mutableIsLoading = MutableStateFlow(true)
   private val mutableFailure = MutableStateFlow<String?>(null)
-  private val mutableCheckboxes = MutableStateFlow<CheckboxesState>(Inactive)
+  private val mutableCheckboxes = MutableStateFlow(restoreCheckboxes())
 
   val checkboxes: StateFlow<CheckboxesState> = mutableCheckboxes.asStateFlow()
 
@@ -73,8 +96,16 @@ class ListRulesViewModel(
     }
 
   init {
+    savedState.setSavedStateProvider(KEY_CHECKBOXES) {
+      encodeToSavedState(mutableCheckboxes.value.toSnapshot())
+    }
     reload()
   }
+
+  private fun restoreCheckboxes(): CheckboxesState =
+    savedState.get<SavedState>(KEY_CHECKBOXES)?.let {
+      decodeFromSavedState<CheckboxesSnapshot>(it).toState()
+    } ?: Inactive
 
   fun reload() {
     mutableIsLoading.update { true }
@@ -145,5 +176,20 @@ class ListRulesViewModel(
       val allExact = conditions.isNotEmpty() && conditions.all { it.operator in EXACT_OPERATORS }
       return if (allExact) score * 2 else score
     }
+  }
+
+  @Serializable
+  private data class CheckboxesSnapshot(val active: Boolean, val ids: Set<RuleId>) {
+    fun toState(): CheckboxesState = if (active) Active(ids.toImmutableSet()) else Inactive
+  }
+
+  private fun CheckboxesState.toSnapshot(): CheckboxesSnapshot =
+    when (this) {
+      Inactive -> CheckboxesSnapshot(active = false, ids = emptySet())
+      is Active -> CheckboxesSnapshot(active = true, ids = ids)
+    }
+
+  private companion object {
+    const val KEY_CHECKBOXES = "checkboxes_state"
   }
 }

--- a/aktual-budget/schedules/vm/src/commonMain/kotlin/aktual/budget/schedules/vm/list/ListSchedulesViewModel.kt
+++ b/aktual-budget/schedules/vm/src/commonMain/kotlin/aktual/budget/schedules/vm/list/ListSchedulesViewModel.kt
@@ -22,12 +22,19 @@ import alakazam.kotlin.requireMessage
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import app.cash.molecule.RecompositionMode.Immediate
 import app.cash.molecule.launchMolecule
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -48,27 +55,38 @@ import kotlinx.serialization.json.JsonPrimitive
 import logcat.logcat
 
 @Stable
-@ViewModelKey
-@ContributesIntoMap(BudgetScope::class)
+@AssistedInject
 class ListSchedulesViewModel(
+  @Assisted private val savedState: SavedStateHandle,
   private val scheduleDao: ScheduleDao,
   private val accountDao: AccountDao,
   private val payeeDao: PayeeDao,
   private val calendar: Calendar,
 ) : ViewModel() {
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(ListSchedulesViewModel::class)
+  @ContributesIntoMap(BudgetScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): ListSchedulesViewModel =
+      create(extras.createSavedStateHandle())
+
+    fun create(@Assisted savedState: SavedStateHandle): ListSchedulesViewModel
+  }
+
   private val mutableSchedules = MutableStateFlow<ImmutableList<Schedule>>(persistentListOf())
   private val mutableIsLoading = MutableStateFlow(true)
   private val mutableFailure = MutableStateFlow<String?>(null)
-  private val mutableFilterText = MutableStateFlow("")
-  private val mutableIsSearchActive = MutableStateFlow(false)
+
+  private val filterText = savedState.getStateFlow(KEY_FILTER_TEXT, "")
+  private val isSearchActive = savedState.getStateFlow(KEY_IS_SEARCH_ACTIVE, false)
 
   val state: StateFlow<ListSchedulesState> =
     viewModelScope.launchMolecule(Immediate) {
       val schedules by mutableSchedules.collectAsState()
       val isLoading by mutableIsLoading.collectAsState()
       val failure by mutableFailure.collectAsState()
-      val filterText by mutableFilterText.collectAsState()
-      val isSearchActive by mutableIsSearchActive.collectAsState()
+      val filterText by filterText.collectAsState()
+      val isSearchActive by isSearchActive.collectAsState()
       @Suppress("BracesOnWhenStatements")
       when {
         isLoading -> Loading
@@ -91,16 +109,16 @@ class ListSchedulesViewModel(
   }
 
   fun openSearch() {
-    mutableIsSearchActive.update { true }
+    savedState[KEY_IS_SEARCH_ACTIVE] = true
   }
 
   fun setFilterText(text: String) {
-    mutableFilterText.update { text }
+    savedState[KEY_FILTER_TEXT] = text
   }
 
   fun clearFilter() {
-    mutableFilterText.update { "" }
-    mutableIsSearchActive.update { false }
+    savedState[KEY_FILTER_TEXT] = ""
+    savedState[KEY_IS_SEARCH_ACTIVE] = false
   }
 
   fun reload() {
@@ -237,5 +255,10 @@ class ListSchedulesViewModel(
     return name?.contains(q, ignoreCase = true) == true ||
       payeeName.contains(q, ignoreCase = true) ||
       accountName.contains(q, ignoreCase = true)
+  }
+
+  private companion object {
+    const val KEY_FILTER_TEXT = "filter_text"
+    const val KEY_IS_SEARCH_ACTIVE = "is_search_active"
   }
 }

--- a/aktual-test/smoke/CLAUDE.md
+++ b/aktual-test/smoke/CLAUDE.md
@@ -27,5 +27,8 @@ Robolectric's native runtime loader hits a zip filesystem conflict on SDK 35. Th
 
 ## Adding a New ViewModel
 
-1. Add a `@Test` function in `ViewModelSmokeTest` using `testVm<YourViewModel>()` or `testAssistedVM<YourVM, YourVM.Factory> { create(...) }`.
+1. Add a `@Test` function in `ViewModelSmokeTest`:
+   - Plain VM → `testVm<YourViewModel>()`
+   - Manual assisted factory (takes a NavKey/spec) → `testAssistedVM<YourVM, YourVM.Factory> { create(...) }`
+   - VM that takes a `SavedStateHandle` (a `ViewModelAssistedFactory` calling `createSavedStateHandle()`) → `testSavedStateVM<YourViewModel>()`, which supplies `CreationExtras` carrying the saved-state plumbing.
 2. Add the VM module as a `commonTestDependencies` implementation dependency in `build.gradle.kts`.

--- a/aktual-test/smoke/build.gradle.kts
+++ b/aktual-test/smoke/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
     implementation(project(":aktual-core:model"))
     implementation(project(":aktual-di:bindings"))
     implementation(project(":aktual-test"))
+    implementation(libs.androidx.lifecycle.viewmodel.savedstate)
 
     // nav use cases needed by the root VMs
     implementation(project(":aktual-app:nav"))

--- a/aktual-test/smoke/src/commonTest/kotlin/aktual/test/ViewModelSmokeTest.kt
+++ b/aktual-test/smoke/src/commonTest/kotlin/aktual/test/ViewModelSmokeTest.kt
@@ -20,9 +20,21 @@ import aktual.prefs.vm.inspect.InspectThemeViewModel
 import aktual.prefs.vm.root.SettingsViewModel
 import aktual.prefs.vm.theme.ThemeSettingsViewModel
 import aktual.prefs.vm.theme.custom.CustomThemeSettingsViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.SAVED_STATE_REGISTRY_OWNER_KEY
+import androidx.lifecycle.VIEW_MODEL_STORE_OWNER_KEY
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.Companion.VIEW_MODEL_KEY
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.enableSavedStateHandles
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
@@ -79,17 +91,17 @@ abstract class ViewModelSmokeTest<G : TestAppGraph> {
 
   protected open fun optionallySkip() = Unit
 
-  @Test fun about() = testVm<AboutViewModel>()
+  @Test fun about() = testSavedStateVM<AboutViewModel>()
 
   @Test fun budgetList() = testVm<ListBudgetsViewModel>()
 
   @Test fun customThemeSettings() = testVm<CustomThemeSettingsViewModel>()
 
-  @Test fun licenses() = testVm<LicensesViewModel>()
+  @Test fun licenses() = testSavedStateVM<LicensesViewModel>()
 
-  @Test fun listRules() = testVm<ListRulesViewModel>()
+  @Test fun listRules() = testSavedStateVM<ListRulesViewModel>()
 
-  @Test fun listSchedules() = testVm<ListSchedulesViewModel>()
+  @Test fun listSchedules() = testSavedStateVM<ListSchedulesViewModel>()
 
   @Test fun login() = testVm<LoginViewModel>()
 
@@ -131,6 +143,12 @@ abstract class ViewModelSmokeTest<G : TestAppGraph> {
     assertThat(viewModel).isNotNull().isInstanceOf(VM::class)
   }
 
+  protected inline fun <reified VM : ViewModel> testSavedStateVM() = runTest {
+    val viewModelFactory = appGraph.runLevelState.viewModelFactory().first()
+    viewModel = viewModelFactory.create(modelClass = VM::class, extras = savedStateCreationExtras())
+    assertThat(viewModel).isNotNull().isInstanceOf(VM::class)
+  }
+
   protected inline fun <
     reified VM : ViewModel,
     reified F : ManualViewModelAssistedFactory,
@@ -143,5 +161,28 @@ abstract class ViewModelSmokeTest<G : TestAppGraph> {
       .isInstanceOf<F>()
       .transform { f -> f.build().also { viewModel = it } }
       .isInstanceOf(VM::class)
+  }
+
+  protected fun savedStateCreationExtras(): CreationExtras {
+    val owner = TestSavedStateOwner().apply { enableSavedStateHandles() }
+    return MutableCreationExtras().apply {
+      this[SAVED_STATE_REGISTRY_OWNER_KEY] = owner
+      this[VIEW_MODEL_STORE_OWNER_KEY] = owner
+      this[VIEW_MODEL_KEY] = "smoke-test"
+    }
+  }
+
+  private class TestSavedStateOwner : SavedStateRegistryOwner, ViewModelStoreOwner {
+    private val lifecycleRegistry = LifecycleRegistry.createUnsafe(this)
+    private val controller =
+      SavedStateRegistryController.create(this).apply { performRestore(null) }
+
+    override val lifecycle: Lifecycle
+      get() = lifecycleRegistry
+
+    override val savedStateRegistry: SavedStateRegistry
+      get() = controller.savedStateRegistry
+
+    override val viewModelStore = ViewModelStore()
   }
 }

--- a/build-logic/src/main/kotlin/aktual/gradle/ModuleViewModel.kt
+++ b/build-logic/src/main/kotlin/aktual/gradle/ModuleViewModel.kt
@@ -19,6 +19,7 @@ class ModuleViewModel : Plugin<Project> {
       kotlin {
         commonMainDependencies {
           api(libs["androidx.lifecycle.viewmodel"])
+          api(libs["androidx.lifecycle.viewmodel.savedstate"])
           api(libs["kotlinx.coroutines.core"])
           api(libs["kotlinx.immutable"])
           api(libs["metrox.viewmodel"])


### PR DESCRIPTION
Closes #1279.

Wires `SavedStateHandle` into the ViewModels that hold transient, user-set UI state so it survives **process death** (plain ViewModels already survive config changes).

## How it works
Metro's `metrox-viewmodel` only delivers `CreationExtras` — and therefore `SavedStateHandle` — through the **assisted-factory** path, so each converted VM moves from a plain `@ViewModelKey` provider to a `ViewModelAssistedFactory` whose `create(extras)` calls `extras.createSavedStateHandle()`. The UI is unchanged: `metroViewModel<VM>()` resolves the factory automatically (assisted factories are tried before plain providers).

Two persistence mechanisms, depending on the state type:

| VM | State persisted | Mechanism |
|----|----------------|-----------|
| `LicensesViewModel` | search term + `isSearchActive` | `getStateFlow` (primitives) |
| `ListSchedulesViewModel` | filter text + `isSearchActive` | `getStateFlow` (primitives) |
| `AboutViewModel` | `CheckUpdatesState` result dialog | kotlinx.serialization + `SavedStateProvider` |
| `ListRulesViewModel` | checkbox selection (`Set<RuleId>`) | kotlinx.serialization + `SavedStateProvider` |

For complex state the `MutableStateFlow` stays the reactive source of truth for Molecule, and a registered `SavedStateProvider` serializes its current value on demand. A mid-flight `AboutViewModel` update check collapses from `Checking` to `Inactive` on restore, since the coroutine that drove it is gone.

## Infrastructure
- `lifecycle-viewmodel-savedstate` is added to the `ModuleViewModel` convention plugin, so every VM module can use `SavedStateHandle`.
- The DI smoke test gains a `testSavedStateVM<>()` helper that builds `CreationExtras` carrying a working `SavedStateHandle` (registry owner + store owner + view-model key), and `about` / `licenses` / `listRules` / `listSchedules` now run through it.

## Scope note
A full audit of all 21 VMs identified these four as the strong candidates. The remaining VMs are either network/db-backed (re-fetchable), derived from already-persisted preferences, one-shot forms (passwords — deliberately re-entered), or bound to jobs that die with the process — so they were left as-is.

## Testing
- `:aktual-about:vm:test` — green
- `:aktual-test:smoke:desktopTest` (`JvmViewModelSmokeTest`, 19 VMs) — green
- `compileAll` for all three changed feature modules — green