### PR TITLE
Scale top bar blur with scroll position

### DIFF
--- a/aktual-about/ui/src/commonMain/kotlin/aktual/about/ui/licenses/LicensesScreen.kt
+++ b/aktual-about/ui/src/commonMain/kotlin/aktual/about/ui/licenses/LicensesScreen.kt
@@ -102,7 +102,7 @@ private fun LicensesScaffold(state: LicensesState, onAction: LicensesActionHandl
     modifier = Modifier.fillMaxSize().imePadding(),
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { Title(isSearchActive, loadedState, onAction) },

--- a/aktual-about/ui/src/commonMain/kotlin/aktual/about/ui/storage/ManageStorageScreen.kt
+++ b/aktual-about/ui/src/commonMain/kotlin/aktual/about/ui/storage/ManageStorageScreen.kt
@@ -127,7 +127,7 @@ private fun ManageStorageScaffold(
     modifier = modifier,
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { Text(Strings.storageToolbar) },

--- a/aktual-budget/list/ui/src/commonMain/kotlin/aktual/budget/list/ui/ListBudgetsScreen.kt
+++ b/aktual-budget/list/ui/src/commonMain/kotlin/aktual/budget/list/ui/ListBudgetsScreen.kt
@@ -148,7 +148,7 @@ internal fun ListBudgetsScaffold(state: ListBudgetsState, onAction: ListBudgetsA
     modifier = Modifier.fillMaxSize(),
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         title = { ScaffoldTitle() },
         actions = { TopBarActions(onAction) },

--- a/aktual-budget/reports/ui/src/commonMain/kotlin/aktual/budget/reports/ui/choosetype/ChooseReportTypeScreen.kt
+++ b/aktual-budget/reports/ui/src/commonMain/kotlin/aktual/budget/reports/ui/choosetype/ChooseReportTypeScreen.kt
@@ -103,7 +103,7 @@ internal fun ChooseReportTypeScaffold(
     modifier = modifier,
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = lazyListState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, lazyListState),
         colors = colors.transparentTopAppBarColors(),
         title = { Text(Strings.reportsChooseTypeTitle) },
       )

--- a/aktual-budget/reports/ui/src/commonMain/kotlin/aktual/budget/reports/ui/dashboard/ReportsDashboardScreen.kt
+++ b/aktual-budget/reports/ui/src/commonMain/kotlin/aktual/budget/reports/ui/dashboard/ReportsDashboardScreen.kt
@@ -92,7 +92,7 @@ internal fun ReportsDashboardScaffold(
     modifier = Modifier.fillMaxSize(),
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         title = { Text(Strings.reportsDashboardTitle) },
         actions = {

--- a/aktual-budget/rules/ui/src/commonMain/kotlin/aktual/budget/rules/ui/edit/EditRuleScreen.kt
+++ b/aktual-budget/rules/ui/src/commonMain/kotlin/aktual/budget/rules/ui/edit/EditRuleScreen.kt
@@ -137,7 +137,7 @@ private fun EditRuleScaffold(
     modifier = modifier.fillMaxSize(),
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { EditRuleTitle(mode) },

--- a/aktual-budget/rules/ui/src/commonMain/kotlin/aktual/budget/rules/ui/list/ListRulesScreen.kt
+++ b/aktual-budget/rules/ui/src/commonMain/kotlin/aktual/budget/rules/ui/list/ListRulesScreen.kt
@@ -42,6 +42,7 @@ import aktual.core.ui.PreviewWithColoredParams
 import aktual.core.ui.blurredTopBar
 import aktual.core.ui.rememberBlurredTopBarState
 import aktual.core.ui.scrollbar
+import aktual.core.ui.topBarBlurOffset
 import aktual.core.ui.transparentTopAppBarColors
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
@@ -65,9 +66,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -132,17 +131,18 @@ private fun ListRulesScaffold(
   // down, and back in as it scrolls up (enter-always behaviour).
   val headerState = rememberCollapsingHeaderState()
 
-  // Blur the bar as soon as content slips behind it. The header eats the first slice of scroll to
-  // collapse itself, so the list won't report canScrollBackward yet — treat a collapsing header as
-  // "scrolled" too, otherwise small scrolls leave a dead zone with no blur.
-  val isScrolled by remember {
-    derivedStateOf { listState.canScrollBackward || headerState.isCollapsing }
-  }
-
   Scaffold(
     modifier = modifier.fillMaxSize().nestedScroll(headerState.nestedScrollConnection),
     topBar = {
-      Column(modifier = Modifier.blurredTopBar(blurState, isScrolled = isScrolled)) {
+      // The header eats the first slice of scroll as it collapses, so fold its collapse distance
+      // into the offset — otherwise small scrolls leave a dead zone with no blur.
+      Column(
+        modifier =
+          Modifier.blurredTopBar(
+            blurState,
+            scrollOffset = { -headerState.offset + listState.topBarBlurOffset() },
+          )
+      ) {
         TopAppBar(
           colors = colors.transparentTopAppBarColors(),
           title = { Text(Strings.rulesToolbar) },

--- a/aktual-budget/schedules/ui/src/commonMain/kotlin/aktual/budget/schedules/ui/list/ListSchedulesScreen.kt
+++ b/aktual-budget/schedules/ui/src/commonMain/kotlin/aktual/budget/schedules/ui/list/ListSchedulesScreen.kt
@@ -111,7 +111,7 @@ private fun ListSchedulesScaffold(
     modifier = modifier.fillMaxSize().imePadding(),
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         title = { Title(isSearchActive, successState, onAction) },
         actions = {

--- a/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsTitleBar.kt
+++ b/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsTitleBar.kt
@@ -43,7 +43,7 @@ internal fun TransactionsTitleBar(
     }
 
   TopAppBar(
-    modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+    modifier = Modifier.blurredTopBar(blurState, listState),
     colors = colors.transparentTopAppBarColors(),
     navigationIcon = { NavBackIconButton { onAction(Action.NavBack) } },
     title = { Text(text = title, maxLines = 1, overflow = Ellipsis) },

--- a/aktual-core/ui/src/commonMain/kotlin/aktual/core/ui/Blur.kt
+++ b/aktual-core/ui/src/commonMain/kotlin/aktual/core/ui/Blur.kt
@@ -14,12 +14,16 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -29,6 +33,7 @@ import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -81,26 +86,47 @@ fun rememberBlurredTopBarState(): BlurredTopBarState {
 
 @Stable data class BlurredTopBarState(val hazeState: HazeState, val blurEnabled: Boolean)
 
-/** Variant that animates between transparent and blurred based on [isScrolled]. */
+/**
+ * Variant that scales the blur with the scroll position. The blur ramps from fully transparent to
+ * fully blurred as [scrollOffset] (in pixels) grows from zero to the top bar's own measured height,
+ * which is captured from the bar's layout pass.
+ */
 @Composable
 fun Modifier.blurredTopBar(
   state: BlurredTopBarState,
-  isScrolled: Boolean,
+  scrollOffset: () -> Float,
   config: BlurConfig = LocalBlurConfig.current,
 ): Modifier {
   if (!state.blurEnabled) return this
 
-  val progress by
-    animateFloatAsState(
-      targetValue = if (isScrolled) 1f else 0f,
-      animationSpec = DefaultAnimationSpec,
-    )
+  var barHeightPx by remember { mutableIntStateOf(0) }
+  val measured = onSizeChanged { barHeightPx = it.height }
 
-  if (progress == 0f) return this
+  val progress by remember {
+    derivedStateOf {
+      val height = barHeightPx
+      if (height <= 0) 0f else (scrollOffset() / height).coerceIn(0f, 1f)
+    }
+  }
+
+  if (progress <= 0f) return measured
 
   val blurStyle = rememberAnimatedHazeStyle(config, progress)
-  return hazeEffect(state.hazeState) { blurEffect { style = blurStyle } }
+  return measured.hazeEffect(state.hazeState) { blurEffect { style = blurStyle } }
 }
+
+/** Convenience overload that derives the scroll offset straight from [listState]. */
+@Composable
+fun Modifier.blurredTopBar(
+  state: BlurredTopBarState,
+  listState: LazyListState,
+  config: BlurConfig = LocalBlurConfig.current,
+): Modifier = blurredTopBar(state, scrollOffset = { listState.topBarBlurOffset() }, config = config)
+
+// Pixels the list content has scrolled up behind the top bar. Once we're past the first item we're
+// definitely fully scrolled, so report a saturating value to hold the blur at max.
+fun LazyListState.topBarBlurOffset(): Float =
+  if (firstVisibleItemIndex > 0) Float.MAX_VALUE else firstVisibleItemScrollOffset.toFloat()
 
 @Composable
 fun Modifier.blurredTopBarContent(

--- a/aktual-metrics/ui/src/commonMain/kotlin/aktual/metrics/ui/MetricsScreen.kt
+++ b/aktual-metrics/ui/src/commonMain/kotlin/aktual/metrics/ui/MetricsScreen.kt
@@ -107,7 +107,7 @@ internal fun MetricsScaffold(
   Scaffold(
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = false),
+        modifier = Modifier.blurredTopBar(blurState, scrollOffset = { 0f }),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { Text(Strings.metricsToolbar) },

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/inspect/InspectThemeScreen.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/inspect/InspectThemeScreen.kt
@@ -110,7 +110,7 @@ private fun InspectThemeScaffold(state: InspectThemeState, onAction: InspectThem
   Scaffold(
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.isScrollInProgress),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { Text(title) },

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/root/SettingsScreen.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/root/SettingsScreen.kt
@@ -78,7 +78,7 @@ private fun SettingsScaffold(state: SettingsScreenState, onAction: SettingsActio
   Scaffold(
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { Text(Strings.settingsToolbar) },

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/theme/ThemeSettingsScreen.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/theme/ThemeSettingsScreen.kt
@@ -78,7 +78,7 @@ private fun ThemeSettingsScaffold(state: ThemeSettingsState, onAction: ThemeSett
   Scaffold(
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { Text(Strings.settingsThemeToolbar) },

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/theme/custom/CustomThemeSettingsScreen.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/theme/custom/CustomThemeSettingsScreen.kt
@@ -165,7 +165,7 @@ private fun CustomThemeSettingsScaffold(
   Scaffold(
     topBar = {
       TopAppBar(
-        modifier = Modifier.blurredTopBar(blurState, isScrolled = listState.canScrollBackward),
+        modifier = Modifier.blurredTopBar(blurState, listState),
         colors = colors.transparentTopAppBarColors(),
         navigationIcon = { NavBackIconButton { onAction(NavBack) } },
         title = { Text(Strings.settingsThemeCustomTitle) },


### PR DESCRIPTION
## What

The blurred top bar now ramps its blur continuously with scroll position instead of snapping on/off. The blur reaches its maximum once the content has scrolled up by the top bar's own height.

## How

- `Modifier.blurredTopBar` now takes a `scrollOffset: () -> Float` (pixels scrolled) instead of `isScrolled: Boolean`. It measures the bar's own height via `onSizeChanged` and derives `progress = (scrollOffset / barHeight).coerceIn(0f, 1f)`, which already drove the blur radius/alpha — so the effect scales smoothly with scroll, no `animateFloatAsState` needed.
- Added a `LazyListState` convenience overload so the common call site is just `Modifier.blurredTopBar(blurState, listState)`. It delegates via a small `LazyListState.topBarBlurOffset()` helper (uses `firstVisibleItemScrollOffset`, saturating once past the first item).

## Call sites

- 12 list-based screens use the clean `LazyListState` overload.
- `MetricsScreen` (non-scrollable) passes `{ 0f }`.
- `ListRulesScreen` (collapsing header) folds the header's collapse distance into the offset (`{ -headerState.offset + listState.topBarBlurOffset() }`) so small scrolls don't leave a dead zone.

## Testing

All affected UI modules compile (`:aktual-core:ui:compileAll` + the 8 dependent UI modules) and the diff is ktfmt-formatted.