### PR TITLE
Remove unnecessary OptIn annotations

### DIFF
--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/Field.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/Field.kt
@@ -8,7 +8,6 @@ import aktual.budget.model.Field.Description
 import aktual.budget.model.Field.Payee
 import alakazam.kotlin.SerializableByString
 import alakazam.kotlin.enumStringSerializer
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -36,7 +35,6 @@ enum class Field(override val value: String) : SerializableByString {
   object Serializer : KSerializer<Field> by enumStringSerializer()
 }
 
-@OptIn(ExperimentalContracts::class)
 fun Field?.isIdField(): Boolean {
   contract { returns(true) implies (this@isIdField != null) }
   return this in FIELDS_WITH_IDS

--- a/aktual-test/api/src/commonMain/kotlin/aktual/test/PrettyJson.kt
+++ b/aktual-test/api/src/commonMain/kotlin/aktual/test/PrettyJson.kt
@@ -1,10 +1,8 @@
 package aktual.test
 
 import aktual.core.model.AktualJson
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 
-@OptIn(ExperimentalSerializationApi::class)
 val PrettyJson =
   Json(from = AktualJson) {
     prettyPrint = true


### PR DESCRIPTION
Removes `@OptIn` annotations (and their now-unused imports) that are no longer required:

- `@OptIn(ExperimentalContracts::class)` on `Field?.isIdField()` — contracts are no longer experimental.
- `@OptIn(ExperimentalSerializationApi::class)` on `PrettyJson` — `prettyPrint` is no longer experimental.