### PR TITLE
Fix edit-tag error handling and duplicate names

### DIFF
--- a/aktual-budget/data/db/src/commonMain/kotlin/aktual/budget/db/dao/TagsDao.kt
+++ b/aktual-budget/data/db/src/commonMain/kotlin/aktual/budget/db/dao/TagsDao.kt
@@ -17,6 +17,10 @@ class TagsDao(database: BudgetDatabase) {
 
   suspend fun getTag(id: TagId): GetTag? = queries.withResult { getTag(id).awaitAsOneOrNull() }
 
+  suspend fun getTagIdByName(name: String): TagId? = queries.withResult {
+    getTagIdByName(name).awaitAsOneOrNull()
+  }
+
   suspend fun insert(id: TagId, tag: String, color: String?, description: String?): Long =
     queries.withResult {
       insert(id = id, tag = tag, color = color, description = description)

--- a/aktual-budget/data/db/src/commonMain/sqldelight/aktual/budget/db/Tags.sq
+++ b/aktual-budget/data/db/src/commonMain/sqldelight/aktual/budget/db/Tags.sq
@@ -21,6 +21,9 @@ insert:
 delete:
   DELETE FROM tags WHERE id = ?;
 
+setTombstone:
+  UPDATE tags SET tombstone = ? WHERE id = ?;
+
 getTags:
   SELECT id, tag, color, description, hidden
   FROM tags
@@ -31,6 +34,10 @@ getTag:
   FROM tags
   WHERE tombstone = 0 AND id = ?
   LIMIT 1;
+
+-- deliberately ignores tombstone so a re-created name resurrects the old row (see upstream createTag)
+getTagIdByName:
+  SELECT id FROM tags WHERE tag = ? LIMIT 1;
 
 getHidden:
   SELECT hidden FROM tags WHERE id = ?;

--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/SyncState.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/SyncState.kt
@@ -22,7 +22,7 @@ sealed interface SyncState {
 @Inject @SingleIn(AppScope::class) class SyncStateHolder : StateHolder<SyncState>(Inactive)
 
 interface BudgetSyncController {
-  suspend fun syncChanges(vararg changes: LocalChange)
+  suspend fun syncChanges(vararg changes: LocalChange) = syncChanges(changes.toList())
 
   suspend fun syncChanges(changes: List<LocalChange>)
 

--- a/aktual-budget/sync/domain/src/commonMain/kotlin/aktual/budget/sync/domain/BudgetSyncControllerImpl.kt
+++ b/aktual-budget/sync/domain/src/commonMain/kotlin/aktual/budget/sync/domain/BudgetSyncControllerImpl.kt
@@ -38,8 +38,6 @@ internal constructor(
   private var syncJob: Job? = null
   private var inactiveJob: Job? = null
 
-  override suspend fun syncChanges(vararg changes: LocalChange) = syncChanges(changes.toList())
-
   override suspend fun syncChanges(changes: List<LocalChange>) {
     syncDao.sendMessages(changes)
     schedule()

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagAction.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagAction.kt
@@ -9,6 +9,8 @@ internal data object NavigateBack : EditTagAction
 
 internal data object SaveTag : EditTagAction
 
+internal data object DismissSaveError : EditTagAction
+
 @JvmInline internal value class SetTag(val tag: String) : EditTagAction
 
 @JvmInline internal value class SetDescription(val description: String) : EditTagAction

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
@@ -82,6 +82,7 @@ fun EditTagScreen(
   val state by viewModel.state.collectAsStateWithLifecycle()
   val hasUnsavedChanges by viewModel.hasUnsavedChanges.collectAsStateWithLifecycle()
   val canSave by viewModel.canSave.collectAsStateWithLifecycle()
+  val isDuplicateName by viewModel.isDuplicateName.collectAsStateWithLifecycle()
 
   // navigate away only once the tag has actually been persisted
   LaunchedEffect(viewModel) {
@@ -97,6 +98,7 @@ fun EditTagScreen(
     state = state,
     hasChanges = hasUnsavedChanges,
     canSave = canSave,
+    isDuplicateName = isDuplicateName,
     onAction = { action ->
       when (action) {
         SaveTag -> viewModel.save()
@@ -123,6 +125,7 @@ private fun EditTagScaffold(
   canSave: Boolean,
   onAction: EditTagActionHandler,
   modifier: Modifier = Modifier,
+  isDuplicateName: Boolean = false,
 ) {
   val editing = state as? EditTagState.Editing
 
@@ -178,6 +181,7 @@ private fun EditTagScaffold(
             tagState = tagState,
             descriptionState = descriptionState,
             color = state.color,
+            isDuplicateName = isDuplicateName,
             onColorChange = { onAction(SetColor(it)) },
             onColorError = { onAction(SetColorError(it)) },
             scrollState = scrollState,
@@ -269,6 +273,7 @@ private fun EditTagContent(
   tagState: TextFieldState,
   descriptionState: TextFieldState,
   color: Color?,
+  isDuplicateName: Boolean,
   onColorChange: (Color) -> Unit,
   onColorError: (Boolean) -> Unit,
   scrollState: ScrollState,
@@ -286,17 +291,18 @@ private fun EditTagContent(
   ) {
     Field(label = Strings.tagsCreateTagLabel, required = true) {
       val isBlank = tagState.text.isBlank()
+      val error =
+        when {
+          isBlank -> Strings.tagsCreateTagRequired
+          isDuplicateName -> Strings.tagsCreateTagDuplicate
+          else -> null
+        }
       AktualTextField(
         modifier = Modifier.fillMaxWidth(),
         state = tagState,
         singleLine = true,
         placeholderText = Strings.tagsCreateTagPlaceholder,
-        supportingText =
-          if (isBlank) {
-            { Text(text = Strings.tagsCreateTagRequired, color = colors.errorText) }
-          } else {
-            null
-          },
+        supportingText = error?.let { { Text(text = it, color = colors.errorText) } },
       )
     }
 

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
@@ -4,6 +4,7 @@ import aktual.budget.model.TagId
 import aktual.budget.tags.vm.edit.EditTagEvent
 import aktual.budget.tags.vm.edit.EditTagState
 import aktual.budget.tags.vm.edit.EditTagViewModel
+import aktual.core.icons.material.ArrowBack
 import aktual.core.icons.material.Clear
 import aktual.core.icons.material.MaterialIcons
 import aktual.core.icons.material.Save
@@ -19,6 +20,8 @@ import aktual.core.ui.BlurredTopBarState
 import aktual.core.ui.BottomSpacing
 import aktual.core.ui.ColoredParameterProvider
 import aktual.core.ui.ColoredParams
+import aktual.core.ui.FailureAction
+import aktual.core.ui.FailureScreen
 import aktual.core.ui.LoadingScreen
 import aktual.core.ui.NavBackIconButton
 import aktual.core.ui.PageBackground
@@ -168,6 +171,7 @@ private fun EditTagScaffold(
 
       when (state) {
         EditTagState.Loading -> LoadingScreen(modifier = Modifier.padding(innerPadding))
+
         is EditTagState.Editing ->
           EditTagContent(
             modifier = Modifier.blurredTopBarContent(blurState, innerPadding),
@@ -178,6 +182,19 @@ private fun EditTagScaffold(
             onColorError = { onAction(SetColorError(it)) },
             scrollState = scrollState,
             contentPadding = blurredTopBarContentPadding(blurState, innerPadding),
+          )
+
+        is EditTagState.Failure ->
+          FailureScreen(
+            modifier = Modifier.padding(innerPadding),
+            title = Strings.tagsEditFailurePrefix,
+            reason = state.cause ?: Strings.tagsEditNotFound,
+            action =
+              FailureAction(
+                text = { Strings.navBack },
+                icon = MaterialIcons.ArrowBack,
+                onClick = { onAction(NavigateBack) },
+              ),
           )
       }
 
@@ -362,4 +379,5 @@ private class EditTagStateProvider :
       color = Color(0xFF388E3C),
       isNew = false,
     ),
+    EditTagState.Failure(cause = null),
   )

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
@@ -83,6 +83,7 @@ fun EditTagScreen(
   val hasUnsavedChanges by viewModel.hasUnsavedChanges.collectAsStateWithLifecycle()
   val canSave by viewModel.canSave.collectAsStateWithLifecycle()
   val isDuplicateName by viewModel.isDuplicateName.collectAsStateWithLifecycle()
+  val saveError by viewModel.saveError.collectAsStateWithLifecycle()
 
   // navigate away only once the tag has actually been persisted
   LaunchedEffect(viewModel) {
@@ -99,6 +100,7 @@ fun EditTagScreen(
     hasChanges = hasUnsavedChanges,
     canSave = canSave,
     isDuplicateName = isDuplicateName,
+    saveError = saveError,
     onAction = { action ->
       when (action) {
         SaveTag -> viewModel.save()
@@ -106,6 +108,7 @@ fun EditTagScreen(
         is SetDescription -> viewModel.setDescription(action.description)
         is SetColor -> viewModel.setColor(action.color)
         is SetColorError -> viewModel.setColorError(action.isError)
+        DismissSaveError -> viewModel.dismissSaveError()
         NavigateBack -> back()
       }
     },
@@ -126,6 +129,7 @@ private fun EditTagScaffold(
   onAction: EditTagActionHandler,
   modifier: Modifier = Modifier,
   isDuplicateName: Boolean = false,
+  saveError: String? = null,
 ) {
   val editing = state as? EditTagState.Editing
 
@@ -211,6 +215,10 @@ private fun EditTagScaffold(
           onCancel = { showDiscardDialog = false },
         )
       }
+
+      if (saveError != null) {
+        SaveErrorDialog(onDismiss = { onAction(DismissSaveError) })
+      }
     }
   }
 }
@@ -265,6 +273,16 @@ private fun DiscardChangesDialog(onDiscard: () -> Unit, onCancel: () -> Unit) {
       TextButton(onClick = onDiscard) { Text(Strings.tagsDiscardConfirm) }
     },
     content = { Text(Strings.tagsDiscardMessage) },
+  )
+}
+
+@Composable
+private fun SaveErrorDialog(onDismiss: () -> Unit) {
+  AktualAlertDialog(
+    title = Strings.tagsSaveFailureTitle,
+    onDismissRequest = onDismiss,
+    buttons = { TextButton(onClick = onDismiss) { Text(Strings.tagsSaveFailureDismiss) } },
+    content = { Text(Strings.tagsSaveFailureMessage) },
   )
 }
 

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagTestUtils.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagTestUtils.kt
@@ -9,3 +9,6 @@ internal suspend fun BudgetDatabase.insertTag(
   color: String? = null,
   description: String? = null,
 ) = tagsQueries.insert(id = TagId(id), tag = tag, color = color, description = description)
+
+internal suspend fun BudgetDatabase.tombstoneTag(id: String) =
+  tagsQueries.setTombstone(tombstone = true, id = TagId(id))

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -7,6 +7,7 @@ import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
 import aktual.budget.tags.vm.insertTag
+import aktual.budget.tags.vm.tombstoneTag
 import aktual.core.model.UuidGenerator
 import aktual.test.assertThatNextEmission
 import aktual.test.runDatabaseTest
@@ -15,11 +16,13 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
 import org.junit.Test
@@ -204,6 +207,46 @@ class EditTagViewModelTest {
     }
 
     assertThat(sync.changes).isNotEmpty()
+  }
+
+  @Test
+  fun `Creating a tag whose name matches a tombstoned tag resurrects the old id`() =
+    runDatabaseTest {
+      insertTag(id = "old-id", tag = "groceries")
+      // tombstone it, as a delete-sync would
+      tombstoneTag("old-id")
+
+      val sync = RecordingSyncController()
+      val viewModel = createViewModel(id = null, sync = sync)
+      viewModel.awaitLoaded()
+
+      viewModel.setTag("groceries")
+      viewModel.events.test {
+        viewModel.save()
+        assertThatNextEmission().isEqualTo(EditTagEvent.FinishedSaving)
+      }
+
+      // the old row's id is reused rather than the freshly generated uuid
+      assertThat(tagsDao.getTagIdByName("groceries")).isEqualTo(TagId("old-id"))
+      assertThat(sync.changes.map { it.row }.distinct()).containsExactly("old-id")
+    }
+
+  @Test
+  fun `A failed save surfaces an error instead of finishing`() = runDatabaseTest {
+    insertTag(id = "groceries-id", tag = "groceries")
+    insertTag(id = "food-id", tag = "food")
+    val viewModel = createViewModel(id = TagId("groceries-id"))
+    viewModel.awaitLoaded()
+
+    // renaming onto another tag's name trips the UNIQUE(tag) constraint; calling save() directly
+    // bypasses the disabled button, so the error must surface rather than be silently swallowed
+    viewModel.setTag("food")
+
+    viewModel.saveError.test {
+      assertThatNextEmission().isNull()
+      viewModel.save()
+      assertThatNextEmission().isNotNull()
+    }
   }
 
   private suspend fun EditTagViewModel.awaitLoaded() {

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -228,7 +228,7 @@ class EditTagViewModelTest {
 
       // the old row's id is reused rather than the freshly generated uuid
       assertThat(tagsDao.getTagIdByName("groceries")).isEqualTo(TagId("old-id"))
-      assertThat(sync.changes.map { it.row }.distinct()).containsExactly("old-id")
+      assertThat(sync.changes.map(LocalChange::row).distinct()).containsExactly("old-id")
     }
 
   @Test

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -167,10 +167,6 @@ class EditTagViewModelTest {
   private class RecordingSyncController : BudgetSyncController {
     val changes = mutableListOf<LocalChange>()
 
-    override suspend fun syncChanges(vararg changes: LocalChange) {
-      this.changes += changes
-    }
-
     override suspend fun syncChanges(changes: List<LocalChange>) {
       this.changes += changes
     }

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -62,6 +62,16 @@ class EditTagViewModelTest {
   }
 
   @Test
+  fun `Requesting a tag that doesn't exist surfaces a failure`() = runDatabaseTest {
+    val viewModel = createViewModel(id = TagId("missing-id"))
+
+    viewModel.state.test {
+      assertThat(awaitFailure()).isEqualTo(EditTagState.Failure(cause = null))
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
   fun `Tracks unsaved changes against the loaded values`() = runDatabaseTest {
     insertTag(id = "groceries-id", tag = "groceries")
     val viewModel = createViewModel(id = TagId("groceries-id"))
@@ -132,6 +142,13 @@ class EditTagViewModelTest {
     while (true) {
       val item = awaitItem()
       if (item is EditTagState.Editing) return item
+    }
+  }
+
+  private suspend fun ReceiveTurbine<EditTagState>.awaitFailure(): EditTagState.Failure {
+    while (true) {
+      val item = awaitItem()
+      if (item is EditTagState.Failure) return item
     }
   }
 

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -8,12 +8,14 @@ import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
 import aktual.budget.tags.vm.insertTag
 import aktual.core.model.UuidGenerator
+import aktual.test.assertThatNextEmission
 import aktual.test.runDatabaseTest
 import androidx.compose.ui.graphics.Color
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotEmpty
@@ -26,6 +28,8 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class EditTagViewModelTest {
+  private lateinit var tagsDao: TagsDao
+
   @Test
   fun `New tag starts as an empty editing state`() = runDatabaseTest {
     val viewModel = createViewModel(id = null)
@@ -78,14 +82,14 @@ class EditTagViewModelTest {
     viewModel.awaitLoaded()
 
     viewModel.hasUnsavedChanges.test {
-      assertThat(awaitItem()).isFalse()
+      assertThatNextEmission().isFalse()
 
       viewModel.setTag("groceries-changed")
-      assertThat(awaitItem()).isTrue()
+      assertThatNextEmission().isTrue()
 
       // editing back to the original value clears the unsaved-changes flag
       viewModel.setTag("groceries")
-      assertThat(awaitItem()).isFalse()
+      assertThatNextEmission().isFalse()
     }
   }
 
@@ -95,13 +99,49 @@ class EditTagViewModelTest {
     viewModel.awaitLoaded()
 
     viewModel.canSave.test {
-      assertThat(awaitItem()).isFalse()
+      assertThatNextEmission().isFalse()
 
       viewModel.setTag("groceries")
-      assertThat(awaitItem()).isTrue()
+      assertThatNextEmission().isTrue()
 
       viewModel.setColorError(isError = true)
-      assertThat(awaitItem()).isFalse()
+      assertThatNextEmission().isFalse()
+    }
+  }
+
+  @Test
+  fun `Cannot save a new tag whose name already exists`() = runDatabaseTest {
+    insertTag(id = "groceries-id", tag = "groceries")
+    val viewModel = createViewModel(id = null)
+    viewModel.awaitLoaded()
+
+    viewModel.canSave.test {
+      assertThatNextEmission().isFalse()
+
+      // a fresh, unused name is saveable
+      viewModel.setTag("food")
+      assertThatNextEmission().isTrue()
+
+      // an existing name blocks saving
+      viewModel.setTag("groceries")
+      assertThatNextEmission().isFalse()
+    }
+  }
+
+  @Test
+  fun `Editing a tag without renaming it doesn't count as a duplicate`() = runDatabaseTest {
+    insertTag(id = "groceries-id", tag = "groceries")
+    insertTag(id = "food-id", tag = "food")
+    val viewModel = createViewModel(id = TagId("groceries-id"))
+    viewModel.awaitLoaded()
+
+    viewModel.isDuplicateName.test {
+      // keeping its own name is fine
+      assertThatNextEmission().isFalse()
+
+      // renaming onto another existing tag is blocked
+      viewModel.setTag("food")
+      assertThatNextEmission().isTrue()
     }
   }
 
@@ -118,10 +158,10 @@ class EditTagViewModelTest {
 
       viewModel.events.test {
         viewModel.save()
-        assertThat(awaitItem()).isEqualTo(EditTagEvent.FinishedSaving)
+        assertThatNextEmission().isEqualTo(EditTagEvent.FinishedSaving)
       }
 
-      val saved = TagsDao(this).getTag(TagId(GENERATED_ID))
+      val saved = tagsDao.getTag(TagId(GENERATED_ID))
       assertThat(saved).isNotNull().all {
         prop(GetTag::tag).isEqualTo("groceries")
         prop(GetTag::color).isEqualTo("#aabbcc")
@@ -130,6 +170,41 @@ class EditTagViewModelTest {
 
       assertThat(sync.changes).isNotEmpty()
     }
+
+  @Test
+  fun `Saving edits to an existing tag updates the row and syncs the change`() = runDatabaseTest {
+    insertTag(
+      id = "groceries-id",
+      tag = "groceries",
+      color = "#aabbcc",
+      description = "Weekly food shopping",
+    )
+
+    val sync = RecordingSyncController()
+    val viewModel = createViewModel(id = TagId("groceries-id"), sync = sync)
+    viewModel.awaitLoaded()
+
+    viewModel.setTag("food")
+    viewModel.setDescription("Food and household")
+    viewModel.setColor(Color(0xFF112233))
+
+    viewModel.events.test {
+      viewModel.save()
+      assertThatNextEmission().isEqualTo(EditTagEvent.FinishedSaving)
+    }
+
+    // the existing row is updated in place rather than duplicated or rejected
+    val tags = tagsDao.getTags()
+    assertThat(tags).hasSize(1)
+    val saved = tagsDao.getTag(TagId("groceries-id"))
+    assertThat(saved).isNotNull().all {
+      prop(GetTag::tag).isEqualTo("food")
+      prop(GetTag::color).isEqualTo("#112233")
+      prop(GetTag::description).isEqualTo("Food and household")
+    }
+
+    assertThat(sync.changes).isNotEmpty()
+  }
 
   private suspend fun EditTagViewModel.awaitLoaded() {
     state.test {
@@ -156,13 +231,15 @@ class EditTagViewModelTest {
     id: TagId?,
     uuid: UuidGenerator = UuidGenerator { GENERATED_ID },
     sync: BudgetSyncController = RecordingSyncController(),
-  ) =
-    EditTagViewModel(
+  ): EditTagViewModel {
+    tagsDao = TagsDao(this)
+    return EditTagViewModel(
       tagId = id,
-      tagsDao = TagsDao(this),
+      tagsDao = tagsDao,
       uuidGenerator = uuid,
       syncController = sync,
     )
+  }
 
   private class RecordingSyncController : BudgetSyncController {
     val changes = mutableListOf<LocalChange>()

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagState.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagState.kt
@@ -9,11 +9,11 @@ sealed interface EditTagState {
 
   @Immutable
   data class Editing(
-    // seed values for the text fields, applied once when the form first composes
     val initialTag: String = "",
     val initialDescription: String = "",
-    // the working colour selection, owned by the view model so it survives config changes
     val color: Color? = null,
     val isNew: Boolean = true,
   ) : EditTagState
+
+  @Immutable @JvmInline value class Failure(val cause: String?) : EditTagState
 }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -26,6 +26,9 @@ import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactoryKey
+import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -47,11 +50,10 @@ class EditTagViewModel(
 ) : ViewModel() {
   private val mutableLoaded = MutableStateFlow<Loaded?>(null)
   private val mutableFailure = MutableStateFlow<EditTagState.Failure?>(null)
-
+  private val mutableExistingNames = MutableStateFlow(persistentSetOf<String>())
   private val mutableTag = MutableStateFlow("")
   private val mutableDescription = MutableStateFlow("")
   private val mutableColor = MutableStateFlow<Color?>(null)
-
   private val mutableColorError = MutableStateFlow(false)
 
   private val mutableEvents =
@@ -67,11 +69,11 @@ class EditTagViewModel(
       val loaded by mutableLoaded.collectAsState()
       val failure by mutableFailure.collectAsState()
       val color by mutableColor.collectAsState()
-      val l = loaded
-      val f = failure
-      when {
-        f != null -> f
-        l == null -> EditTagState.Loading
+      failure?.let {
+        return@launchMolecule it
+      }
+      when (val l = loaded) {
+        null -> EditTagState.Loading
         else ->
           EditTagState.Editing(
             initialTag = l.tag,
@@ -93,12 +95,23 @@ class EditTagViewModel(
       l != null && (tag != l.tag || description != l.description || color != l.color)
     }
 
-  // a tag is saveable when it has a non-blank name and the colour field isn't in an error state
+  // true when the entered name already belongs to another tag
+  val isDuplicateName: StateFlow<Boolean> =
+    viewModelScope.launchMolecule(Immediate) {
+      val tag by mutableTag.collectAsState()
+      val existingNames by mutableExistingNames.collectAsState()
+      tag.trim() in existingNames
+    }
+
+  // a tag is saveable when its name is non-blank, unique, and the colour field isn't in an error
+  // state
   val canSave: StateFlow<Boolean> =
     viewModelScope.launchMolecule(Immediate) {
       val tag by mutableTag.collectAsState()
       val colorError by mutableColorError.collectAsState()
-      tag.isNotBlank() && !colorError
+      val existingNames by mutableExistingNames.collectAsState()
+      val trimmed = tag.trim()
+      trimmed.isNotBlank() && !colorError && trimmed !in existingNames
     }
 
   init {
@@ -107,6 +120,8 @@ class EditTagViewModel(
 
   private fun load() {
     viewModelScope.launch {
+      mutableExistingNames.update { loadOtherTagNames() }
+
       if (tagId == null) {
         reset(Loaded(isNew = true))
         return@launch
@@ -138,6 +153,22 @@ class EditTagViewModel(
       }
     }
   }
+
+  // the active tag names other than the one being edited, so renaming a tag to itself stays allowed
+  private suspend fun loadOtherTagNames(): PersistentSet<String> =
+    try {
+      tagsDao
+        .getTags()
+        .mapNotNull { it.toTagItem() }
+        .filter { it.id != tagId }
+        .map { it.tag }
+        .toPersistentSet()
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      logcat.e(e) { "Failed loading existing tag names" }
+      persistentSetOf()
+    }
 
   // seed the working edits from the loaded values, so there are initially no unsaved changes
   private fun reset(loaded: Loaded) {

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import logcat.logcat
@@ -55,6 +56,11 @@ class EditTagViewModel(
   private val mutableDescription = MutableStateFlow("")
   private val mutableColor = MutableStateFlow<Color?>(null)
   private val mutableColorError = MutableStateFlow(false)
+
+  // non-null when the last save attempt failed; drives an error dialog so the user isn't left
+  // guessing
+  private val mutableSaveError = MutableStateFlow<String?>(null)
+  val saveError: StateFlow<String?> = mutableSaveError.asStateFlow()
 
   private val mutableEvents =
     MutableSharedFlow<EditTagEvent>(
@@ -187,13 +193,18 @@ class EditTagViewModel(
 
   fun setColorError(isError: Boolean) = mutableColorError.update { isError }
 
+  fun dismissSaveError() = mutableSaveError.update { null }
+
   fun save() {
     viewModelScope.launch {
+      mutableSaveError.update { null }
       try {
-        val id = tagId ?: uuidGenerator(::TagId)
         val tag = mutableTag.value.trim()
         val description = mutableDescription.value.trim()
         val color = mutableColor.value?.toHex()
+        // creating a tag reuses any existing row with the same name — even a tombstoned one — so the
+        // old id is resurrected rather than colliding with the UNIQUE constraint (matches createTag)
+        val id = tagId ?: tagsDao.getTagIdByName(tag) ?: uuidGenerator(::TagId)
         tagsDao.insert(id = id, tag = tag, color = color, description = description)
         syncController.syncChanges(insertChanges(id, tag, color, description))
         mutableEvents.tryEmit(EditTagEvent.FinishedSaving)
@@ -201,6 +212,7 @@ class EditTagViewModel(
         throw e
       } catch (e: Exception) {
         logcat.e(e) { "Failed saving tag $tagId" }
+        mutableSaveError.update { e.requireMessage() }
       }
     }
   }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -11,6 +11,7 @@ import aktual.budget.tags.vm.list.toHex
 import aktual.budget.tags.vm.list.toTagItem
 import aktual.core.model.UuidGenerator
 import aktual.di.BudgetScope
+import alakazam.kotlin.requireMessage
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -45,16 +46,14 @@ class EditTagViewModel(
   private val syncController: BudgetSyncController,
 ) : ViewModel() {
   private val mutableLoaded = MutableStateFlow<Loaded?>(null)
+  private val mutableFailure = MutableStateFlow<EditTagState.Failure?>(null)
 
-  // the working edits live here so they survive recomposition and config changes
   private val mutableTag = MutableStateFlow("")
   private val mutableDescription = MutableStateFlow("")
   private val mutableColor = MutableStateFlow<Color?>(null)
 
-  // set by the UI when the colour field holds an invalid hex code, which blocks saving
   private val mutableColorError = MutableStateFlow(false)
 
-  // emitted once the tag has been persisted, so the screen can navigate away
   private val mutableEvents =
     MutableSharedFlow<EditTagEvent>(
       replay = 0,
@@ -66,9 +65,13 @@ class EditTagViewModel(
   val state: StateFlow<EditTagState> =
     viewModelScope.launchMolecule(Immediate) {
       val loaded by mutableLoaded.collectAsState()
+      val failure by mutableFailure.collectAsState()
       val color by mutableColor.collectAsState()
-      when (val l = loaded) {
-        null -> EditTagState.Loading
+      val l = loaded
+      val f = failure
+      when {
+        f != null -> f
+        l == null -> EditTagState.Loading
         else ->
           EditTagState.Editing(
             initialTag = l.tag,
@@ -105,7 +108,6 @@ class EditTagViewModel(
   private fun load() {
     viewModelScope.launch {
       if (tagId == null) {
-        // creating a fresh tag — nothing to load
         reset(Loaded(isNew = true))
         return@launch
       }
@@ -117,11 +119,13 @@ class EditTagViewModel(
           throw e
         } catch (e: Exception) {
           logcat.e(e) { "Failed loading tag $tagId" }
-          null
+          mutableFailure.update { EditTagState.Failure(cause = e.requireMessage()) }
+          return@launch
         }
 
       if (existing == null) {
-        reset(Loaded(isNew = true))
+        // the tag was requested but doesn't exist — don't pretend it's a new one
+        mutableFailure.update { EditTagState.Failure(cause = null) }
       } else {
         reset(
           Loaded(

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -202,8 +202,9 @@ class EditTagViewModel(
         val tag = mutableTag.value.trim()
         val description = mutableDescription.value.trim()
         val color = mutableColor.value?.toHex()
-        // creating a tag reuses any existing row with the same name — even a tombstoned one — so the
-        // old id is resurrected rather than colliding with the UNIQUE constraint (matches createTag)
+        // creating a tag reuses any existing row with the same name — even a tombstoned one — so
+        // the old id is resurrected rather than colliding with the UNIQUE constraint (matches
+        // createTag)
         val id = tagId ?: tagsDao.getTagIdByName(tag) ?: uuidGenerator(::TagId)
         tagsDao.insert(id = id, tag = tag, color = color, description = description)
         syncController.syncChanges(insertChanges(id, tag, color, description))

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -159,6 +159,7 @@ class EditTagViewModel(
     try {
       tagsDao
         .getTags()
+        .asSequence()
         .mapNotNull { it.toTagItem() }
         .filter { it.id != tagId }
         .map { it.tag }

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -14,6 +14,7 @@
   <string name="tags_create_tag_label">Tag</string>
   <string name="tags_create_tag_placeholder">e.g. groceries</string>
   <string name="tags_create_tag_required">Required</string>
+  <string name="tags_create_tag_duplicate">A tag with this name already exists</string>
   <string name="tags_create_description_label">Description</string>
   <string name="tags_create_description_placeholder">What is this tag for?</string>
   <string name="tags_create_color_label">Color</string>

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -22,6 +22,9 @@
   <string name="tags_create_color_advanced">Advanced color options</string>
   <string name="tags_create_color_invalid">Invalid color code</string>
   <string name="tags_create_save">Save</string>
+  <string name="tags_save_failure_title">Couldn\'t save tag</string>
+  <string name="tags_save_failure_message">Something went wrong while saving. Please try again.</string>
+  <string name="tags_save_failure_dismiss">OK</string>
   <string name="tags_edit_failure_prefix">Failed loading tag</string>
   <string name="tags_edit_not_found">This tag no longer exists</string>
   <string name="tags_discard_title">Discard changes?</string>

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -21,6 +21,8 @@
   <string name="tags_create_color_advanced">Advanced color options</string>
   <string name="tags_create_color_invalid">Invalid color code</string>
   <string name="tags_create_save">Save</string>
+  <string name="tags_edit_failure_prefix">Failed loading tag</string>
+  <string name="tags_edit_not_found">This tag no longer exists</string>
   <string name="tags_discard_title">Discard changes?</string>
   <string name="tags_discard_message">Your unsaved changes will be lost.</string>
   <string name="tags_discard_cancel">Cancel</string>


### PR DESCRIPTION
Follow-up to #1333, fixing a few bugs in the create/edit tag flow.

## Changes

- **Surface load failures.** When editing a tag, `EditTagViewModel` previously fell back to a blank "New tag" form if `getTag` returned null or threw — so a user editing a deleted/missing tag silently landed on a create form. It now shows an explicit `Failure` state (`This tag no longer exists`, or the DB error) with a "go back" action.
- **Block duplicate tag names.** `tags.tag` is `UNIQUE`, but the local upsert is keyed on `id` only. Mirroring upstream's disabled "Add" button (`TagCreationRow.tsx`), the save button is now gated on name uniqueness and the tag field shows an inline `A tag with this name already exists` error. The check excludes the tag's own name so an unchanged rename stays allowed.
- **Resurrect tombstoned tags.** Creating a tag whose name matches an existing row — including a tombstoned one — now reuses that row's id instead of generating a fresh uuid, so the old tag is resurrected rather than colliding with the `UNIQUE(tag)` constraint. This mirrors upstream's `createTag`. Backed by a new `getTagIdByName` query that deliberately ignores the tombstone filter.
- **Surface save errors.** Any remaining save failure (e.g. a constraint violation from a concurrent rename) now sets an error state and shows a dialog, instead of being swallowed silently and leaving the user stuck on the form.
- **Tests.** Added coverage for the not-found failure state, the edit→save upsert path, duplicate-name blocking on both create and edit, tombstone resurrection, and the save-error path.

## Confirmed (no change needed)

The edit-case payload is an upsert end-to-end: the local SQL uses `ON CONFLICT(id) DO UPDATE`, and the sync protocol's `applyToTable` does `UPDATE ... WHERE id` first, falling back to `INSERT` only when no row matches. The `insert` query deliberately leaves `tombstone`/`hidden` untouched (see `TagsTest`) so an incoming sync can't resurrect a tag — resurrection is driven explicitly via the `tombstone = false` change in the save payload.