### PR TITLE
Swipe to delete tags

### DIFF
--- a/.claude/agents/gradle-runner.md
+++ b/.claude/agents/gradle-runner.md
@@ -25,8 +25,9 @@ script which handles output capture, filtering, and exit-code propagation:
 # Compile one module (most common)
 ./scripts/gradle-run.sh :<module>:compileAll
 
-# Run tests for one module
-./scripts/gradle-run.sh :<module>:test --continue
+# Run tests for one module — `:<module>:test` is AMBIGUOUS in this project; use a
+# concrete task: `testAll`, `testAndroidHostTest`, or `testAndroid`
+./scripts/gradle-run.sh :<module>:testAndroidHostTest --continue
 
 # Format check
 ./scripts/ktfmt.sh check 2>&1 | grep -v "^$" | head -50
@@ -38,9 +39,15 @@ Always pass **timeout: 600000** (10 minutes) to the Bash tool for all Gradle com
 
 ## Rules
 
-1. **Run exactly one Bash command** per invocation — never run commands in parallel
-2. Report filtered output verbatim to the caller
-3. Clearly state whether the build **succeeded** or **failed**
-4. Do **not** attempt to fix issues — only report findings
-5. Do **not** read or modify source files
-6. Do **not** run `./gradlew build` or `./gradlew allTests` — those are full-project builds and will peg the machine
+1. Run Gradle commands **sequentially**, one Bash call at a time — never in parallel
+2. **Report every command the caller asked for, separately and explicitly** — state each
+   one's outcome (succeeded / failed) even when an earlier or later command fails. Never
+   collapse the report down to just the failing command; a silent omission reads to the
+   caller as "didn't run"
+3. Report filtered output verbatim to the caller
+4. If a task name is **ambiguous** (Gradle replies "task '...' is ambiguous ... Candidates
+   are: ..."), report the failure AND list the candidate task names verbatim so the caller
+   can pick one — do not guess and re-run
+5. Do **not** attempt to fix issues — only report findings
+6. Do **not** read or modify source files
+7. Do **not** run `./gradlew build` or `./gradlew allTests` — those are full-project builds and will peg the machine

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagScreen.kt
@@ -217,7 +217,7 @@ private fun EditTagScaffold(
       }
 
       if (saveError != null) {
-        SaveErrorDialog(onDismiss = { onAction(DismissSaveError) })
+        SaveErrorDialog(message = saveError, onDismiss = { onAction(DismissSaveError) })
       }
     }
   }
@@ -277,12 +277,12 @@ private fun DiscardChangesDialog(onDiscard: () -> Unit, onCancel: () -> Unit) {
 }
 
 @Composable
-private fun SaveErrorDialog(onDismiss: () -> Unit) {
+private fun SaveErrorDialog(message: String, onDismiss: () -> Unit) {
   AktualAlertDialog(
     title = Strings.tagsSaveFailureTitle,
     onDismissRequest = onDismiss,
     buttons = { TextButton(onClick = onDismiss) { Text(Strings.tagsSaveFailureDismiss) } },
-    content = { Text(Strings.tagsSaveFailureMessage) },
+    content = { Text(message) },
   )
 }
 

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
@@ -17,6 +17,8 @@ internal data object CreateTag : ListTagsAction
 
 @JvmInline internal value class EditTag(val id: TagId) : ListTagsAction
 
+@JvmInline internal value class DeleteTag(val id: TagId) : ListTagsAction
+
 @Immutable
 internal fun interface ListTagsActionHandler {
   operator fun invoke(action: ListTagsAction)

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsDS.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsDS.kt
@@ -8,6 +8,7 @@ internal object ListTagsDS {
   val listPadding = PaddingValues(horizontal = 16.dp)
   val listItemSpacing = 8.dp
   val itemPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp)
+  val deleteButtonWidth = 80.dp
   val itemHorizontalSpacing = 8.dp
   val itemContentSpacing = 6.dp
   val chipShape = RoundedCornerShape(size = 16.dp)

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -17,6 +17,8 @@ import aktual.core.icons.material.SearchOff
 import aktual.core.l10n.Plurals
 import aktual.core.l10n.Res
 import aktual.core.l10n.Strings
+import aktual.core.l10n.tags_delete_failed
+import aktual.core.l10n.tags_delete_failed_unknown
 import aktual.core.l10n.tags_deleted
 import aktual.core.nav.EditTagNavigator
 import aktual.core.ui.AktualTextField
@@ -29,10 +31,12 @@ import aktual.core.ui.ColoredParams
 import aktual.core.ui.FailureAction
 import aktual.core.ui.FailureScreen
 import aktual.core.ui.LoadingScreen
+import aktual.core.ui.LocalBottomSpacing
 import aktual.core.ui.PageBackground
 import aktual.core.ui.PortraitPreview
 import aktual.core.ui.PreviewWithColoredParams
 import aktual.core.ui.blurredTopBar
+import aktual.core.ui.bottomNavBarPadding
 import aktual.core.ui.rememberBlurredTopBarState
 import aktual.core.ui.scrollbar
 import aktual.core.ui.transparentTopAppBarColors
@@ -71,6 +75,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.zacsweers.metrox.viewmodel.metroViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -86,11 +91,22 @@ internal fun ListTagsScreen(
   val state by viewModel.state.collectAsStateWithLifecycle()
   val snackbar = remember { SnackbarHostState() }
 
+  // refresh on return (e.g. after creating or editing a tag) so the list reflects the changes
+  LifecycleResumeEffect(viewModel) {
+    viewModel.reload(showLoading = false)
+    onPauseOrDispose {}
+  }
+
   LaunchedEffect(viewModel) {
     viewModel.events.collect { event ->
       when (event) {
         is ListTagsEvent.Deleted ->
           snackbar.showSnackbar(getString(Res.string.tags_deleted, event.tag))
+        is ListTagsEvent.DeleteFailed ->
+          snackbar.showSnackbar(
+            event.tag?.let { getString(Res.string.tags_delete_failed, it) }
+              ?: getString(Res.string.tags_delete_failed_unknown)
+          )
       }
     }
   }
@@ -147,7 +163,12 @@ private fun ListTagsScaffold(
         },
       )
     },
-    snackbarHost = { SnackbarHost(snackbarHostState) },
+    snackbarHost = {
+      SnackbarHost(
+        hostState = snackbarHostState,
+        modifier = Modifier.padding(bottom = LocalBottomSpacing.current + bottomNavBarPadding()),
+      )
+    },
   ) { innerPadding ->
     Box(modifier = Modifier.fillMaxSize()) {
       PageBackground()

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -2,6 +2,7 @@ package aktual.budget.tags.ui.list
 
 import aktual.budget.tags.vm.list.Empty
 import aktual.budget.tags.vm.list.Failure
+import aktual.budget.tags.vm.list.ListTagsEvent
 import aktual.budget.tags.vm.list.ListTagsState
 import aktual.budget.tags.vm.list.ListTagsViewModel
 import aktual.budget.tags.vm.list.Loading
@@ -13,7 +14,9 @@ import aktual.core.icons.material.Refresh
 import aktual.core.icons.material.Search
 import aktual.core.icons.material.SearchOff
 import aktual.core.l10n.Plurals
+import aktual.core.l10n.Res
 import aktual.core.l10n.Strings
+import aktual.core.l10n.tags_deleted
 import aktual.core.nav.EditTagNavigator
 import aktual.core.ui.AktualTextField
 import aktual.core.ui.AktualTheme.colors
@@ -50,6 +53,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -67,6 +72,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.zacsweers.metrox.viewmodel.metroViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import org.jetbrains.compose.resources.getString
 
 @Composable
 internal fun ListTagsScreen(
@@ -75,10 +81,21 @@ internal fun ListTagsScreen(
   viewModel: ListTagsViewModel = metroViewModel(),
 ) {
   val state by viewModel.state.collectAsStateWithLifecycle()
+  val snackbar = remember { SnackbarHostState() }
+
+  LaunchedEffect(viewModel) {
+    viewModel.events.collect { event ->
+      when (event) {
+        is ListTagsEvent.Deleted ->
+          snackbar.showSnackbar(getString(Res.string.tags_deleted, event.tag))
+      }
+    }
+  }
 
   ListTagsScaffold(
     modifier = modifier,
     state = state,
+    snackbarHostState = snackbar,
     onAction = { action ->
       when (action) {
         Reload -> viewModel.reload()
@@ -87,6 +104,7 @@ internal fun ListTagsScreen(
         ClearFilter -> viewModel.clearFilter()
         CreateTag -> toEdit()
         is EditTag -> toEdit(action.id)
+        is DeleteTag -> viewModel.delete(action.id)
       }
     },
   )
@@ -97,6 +115,7 @@ private fun ListTagsScaffold(
   state: ListTagsState,
   onAction: ListTagsActionHandler,
   modifier: Modifier = Modifier,
+  snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
   val blurState = rememberBlurredTopBarState()
   val listState = rememberLazyListState()
@@ -125,6 +144,7 @@ private fun ListTagsScaffold(
         },
       )
     },
+    snackbarHost = { SnackbarHost(snackbarHostState) },
   ) { innerPadding ->
     Box(modifier = Modifier.fillMaxSize()) {
       PageBackground()

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -92,6 +92,7 @@ internal fun ListTagsScreen(
   val snackbar = remember { SnackbarHostState() }
 
   // refresh on return (e.g. after creating or editing a tag) so the list reflects the changes
+  @Suppress("ComposeViewModelForwarding")
   LifecycleResumeEffect(viewModel) {
     viewModel.reload(showLoading = false)
     onPauseOrDispose {}

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -1,5 +1,6 @@
 package aktual.budget.tags.ui.list
 
+import aktual.budget.model.TagId
 import aktual.budget.tags.vm.list.Empty
 import aktual.budget.tags.vm.list.Failure
 import aktual.budget.tags.vm.list.ListTagsEvent
@@ -61,7 +62,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -286,6 +289,9 @@ private fun TagsList(
   onAction: ListTagsActionHandler,
   modifier: Modifier = Modifier,
 ) {
+  // only one row may be swiped open at a time — opening another closes the previous one
+  var openTagId by remember { mutableStateOf<TagId?>(null) }
+
   LazyColumn(
     modifier = modifier.fillMaxSize().scrollbar(listState),
     state = listState,
@@ -296,6 +302,15 @@ private fun TagsList(
       TagItem(
         modifier = Modifier.animateItem(),
         tag = tag,
+        isOpen = openTagId == tag.id,
+        onOpenChange = { open ->
+          openTagId =
+            when {
+              open -> tag.id
+              openTagId == tag.id -> null
+              else -> openTagId
+            }
+        },
         onAction = onAction,
       )
     }

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
@@ -2,6 +2,8 @@ package aktual.budget.tags.ui.list
 
 import aktual.budget.tags.ui.contrastingTextColor
 import aktual.budget.tags.vm.list.TagItem
+import aktual.core.icons.material.Delete
+import aktual.core.icons.material.MaterialIcons
 import aktual.core.l10n.Strings
 import aktual.core.ui.AktualTheme.colors
 import aktual.core.ui.AktualTheme.typography
@@ -12,27 +14,87 @@ import aktual.core.ui.RowShape
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import kotlin.math.roundToInt
+
+// the two resting positions of a swipeable row: closed, or swiped left to reveal the delete button
+private enum class SwipeState {
+  Closed,
+  Open,
+}
 
 @Composable
 internal fun TagItem(
+  tag: TagItem,
+  onAction: ListTagsActionHandler,
+  modifier: Modifier = Modifier,
+) {
+  val buttonWidthPx = with(LocalDensity.current) { ListTagsDS.deleteButtonWidth.toPx() }
+  val swipeState =
+    remember(buttonWidthPx) {
+      AnchoredDraggableState(initialValue = SwipeState.Closed).apply {
+        updateAnchors(
+          DraggableAnchors {
+            SwipeState.Closed at 0f
+            SwipeState.Open at -buttonWidthPx
+          }
+        )
+      }
+    }
+
+  Box(modifier = modifier.fillMaxWidth().clip(RowShape)) {
+    // the red delete button sits behind the row, revealed as it's dragged left
+    Row(modifier = Modifier.matchParentSize(), horizontalArrangement = Arrangement.End) {
+      DeleteButton(
+        modifier = Modifier.fillMaxHeight().width(ListTagsDS.deleteButtonWidth),
+        onClick = { onAction(DeleteTag(tag.id)) },
+      )
+    }
+
+    TagItemRow(
+      tag = tag,
+      onAction = onAction,
+      modifier =
+        Modifier.offset {
+            val x = swipeState.offset
+            IntOffset(x = if (x.isNaN()) 0 else x.roundToInt(), y = 0)
+          }
+          .anchoredDraggable(state = swipeState, orientation = Orientation.Horizontal),
+    )
+  }
+}
+
+@Composable
+private fun TagItemRow(
   tag: TagItem,
   onAction: ListTagsActionHandler,
   modifier: Modifier = Modifier,
@@ -64,6 +126,24 @@ internal fun TagItem(
         overflow = TextOverflow.Ellipsis,
       )
     }
+  }
+}
+
+@Composable
+private fun DeleteButton(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val background = colors.errorText
+  Box(
+    modifier = modifier.background(background).clickable(onClick = onClick),
+    contentAlignment = Alignment.Center,
+  ) {
+    Icon(
+      imageVector = MaterialIcons.Delete,
+      contentDescription = Strings.tagsDelete,
+      tint = background.contrastingTextColor(),
+    )
   }
 }
 

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,7 +31,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -55,6 +60,8 @@ private enum class SwipeState {
 @Composable
 internal fun TagItem(
   tag: TagItem,
+  isOpen: Boolean,
+  onOpenChange: (Boolean) -> Unit,
   onAction: ListTagsActionHandler,
   modifier: Modifier = Modifier,
 ) {
@@ -70,6 +77,20 @@ internal fun TagItem(
         )
       }
     }
+
+  // tell the parent when this row settles open or closed, so it can keep only one row open
+  val currentOnOpenChange by rememberUpdatedState(onOpenChange)
+  LaunchedEffect(swipeState) {
+    snapshotFlow { swipeState.settledValue }
+      .collect { settled -> currentOnOpenChange(settled == SwipeState.Open) }
+  }
+
+  // when another row becomes the open one, slide this row shut
+  LaunchedEffect(isOpen) {
+    if (!isOpen && swipeState.currentValue != SwipeState.Closed) {
+      swipeState.animateTo(SwipeState.Closed)
+    }
+  }
 
   Box(modifier = modifier.fillMaxWidth().clip(RowShape)) {
     // the red delete button sits behind the row, revealed as it's dragged left
@@ -178,4 +199,7 @@ private class TagItemProvider : ColoredParameterProvider<TagItem>(TagsPreview.al
 @Composable
 private fun PreviewTagItem(
   @PreviewParameter(TagItemProvider::class) params: ColoredParams<TagItem>
-) = PreviewWithColoredParams(params) { TagItem(tag = this, onAction = {}) }
+) =
+  PreviewWithColoredParams(params) {
+    TagItem(tag = this, isOpen = false, onOpenChange = {}, onAction = {})
+  }

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -85,6 +87,15 @@ internal fun TagItem(
       .collect { settled -> currentOnOpenChange(settled == SwipeState.Open) }
   }
 
+  // claim the "open" slot the moment a drag begins, so any other open row closes straight
+  // away rather than waiting for this drag to finish
+  val interactionSource = remember { MutableInteractionSource() }
+  LaunchedEffect(interactionSource) {
+    interactionSource.interactions.collect { interaction ->
+      if (interaction is DragInteraction.Start) currentOnOpenChange(true)
+    }
+  }
+
   // when another row becomes the open one, slide this row shut
   LaunchedEffect(isOpen) {
     if (!isOpen && swipeState.currentValue != SwipeState.Closed) {
@@ -109,7 +120,11 @@ internal fun TagItem(
             val x = swipeState.offset
             IntOffset(x = if (x.isNaN()) 0 else x.roundToInt(), y = 0)
           }
-          .anchoredDraggable(state = swipeState, orientation = Orientation.Horizontal),
+          .anchoredDraggable(
+            state = swipeState,
+            orientation = Orientation.Horizontal,
+            interactionSource = interactionSource,
+          ),
     )
   }
 }

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagTestUtils.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagTestUtils.kt
@@ -1,7 +1,19 @@
 package aktual.budget.tags.vm
 
 import aktual.budget.db.BudgetDatabase
+import aktual.budget.model.BudgetSyncController
+import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
+
+internal class RecordingSyncController : BudgetSyncController {
+  val changes = mutableListOf<LocalChange>()
+
+  override suspend fun syncChanges(changes: List<LocalChange>) {
+    this.changes += changes
+  }
+
+  override fun schedule() = Unit
+}
 
 internal suspend fun BudgetDatabase.insertTag(
   id: String,

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagTestUtils.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagTestUtils.kt
@@ -1,19 +1,7 @@
 package aktual.budget.tags.vm
 
 import aktual.budget.db.BudgetDatabase
-import aktual.budget.model.BudgetSyncController
-import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
-
-internal class RecordingSyncController : BudgetSyncController {
-  val changes = mutableListOf<LocalChange>()
-
-  override suspend fun syncChanges(changes: List<LocalChange>) {
-    this.changes += changes
-  }
-
-  override fun schedule() = Unit
-}
 
 internal suspend fun BudgetDatabase.insertTag(
   id: String,

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -6,10 +6,10 @@ import aktual.budget.db.dao.TagsDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
-import aktual.budget.tags.vm.RecordingSyncController
 import aktual.budget.tags.vm.insertTag
 import aktual.budget.tags.vm.tombstoneTag
 import aktual.core.model.UuidGenerator
+import aktual.test.TestSyncController
 import aktual.test.assertThatNextEmission
 import aktual.test.runDatabaseTest
 import androidx.compose.ui.graphics.Color
@@ -152,7 +152,7 @@ class EditTagViewModelTest {
   @Test
   fun `Saving a new tag persists it, syncs the change and emits the saved event`() =
     runDatabaseTest {
-      val sync = RecordingSyncController()
+      val sync = TestSyncController()
       val viewModel = createViewModel(id = null, sync = sync)
       viewModel.awaitLoaded()
 
@@ -184,7 +184,7 @@ class EditTagViewModelTest {
       description = "Weekly food shopping",
     )
 
-    val sync = RecordingSyncController()
+    val sync = TestSyncController()
     val viewModel = createViewModel(id = TagId("groceries-id"), sync = sync)
     viewModel.awaitLoaded()
 
@@ -217,7 +217,7 @@ class EditTagViewModelTest {
       // tombstone it, as a delete-sync would
       tombstoneTag("old-id")
 
-      val sync = RecordingSyncController()
+      val sync = TestSyncController()
       val viewModel = createViewModel(id = null, sync = sync)
       viewModel.awaitLoaded()
 
@@ -274,7 +274,7 @@ class EditTagViewModelTest {
   private fun BudgetDatabase.createViewModel(
     id: TagId?,
     uuid: UuidGenerator = UuidGenerator { GENERATED_ID },
-    sync: BudgetSyncController = RecordingSyncController(),
+    sync: BudgetSyncController = TestSyncController(),
   ): EditTagViewModel {
     tagsDao = TagsDao(this)
     return EditTagViewModel(

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -6,6 +6,7 @@ import aktual.budget.db.dao.TagsDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
+import aktual.budget.tags.vm.RecordingSyncController
 import aktual.budget.tags.vm.insertTag
 import aktual.budget.tags.vm.tombstoneTag
 import aktual.core.model.UuidGenerator
@@ -282,16 +283,6 @@ class EditTagViewModelTest {
       uuidGenerator = uuid,
       syncController = sync,
     )
-  }
-
-  private class RecordingSyncController : BudgetSyncController {
-    val changes = mutableListOf<LocalChange>()
-
-    override suspend fun syncChanges(changes: List<LocalChange>) {
-      this.changes += changes
-    }
-
-    override fun schedule() = Unit
   }
 
   private companion object {

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -140,6 +140,41 @@ class ListTagsViewModelTest {
     }
   }
 
+  @Test
+  fun `Delete failure emits a DeleteFailed event and keeps the tag`() = runDatabaseTest {
+    insertTag(id = "groceries-id", tag = "groceries")
+
+    val viewModel = createViewModel(sync = FailingSyncController())
+
+    // wait for the initial load
+    viewModel.state.test {
+      assertThat(awaitItem()).isInstanceOf(Success::class).prop(Success::tags).hasSize(1)
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    // a failing sync surfaces a DeleteFailed event rather than failing silently
+    viewModel.events.test {
+      viewModel.delete(TagId("groceries-id"))
+      assertThat(awaitItem()).isEqualTo(ListTagsEvent.DeleteFailed("groceries"))
+    }
+
+    // and the tag is still present since the delete didn't go through
+    viewModel.state.test {
+      assertThat(awaitItem())
+        .isInstanceOf(Success::class)
+        .prop(Success::tags)
+        .extracting(TagItem::tag)
+        .containsExactly("groceries")
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
   private fun BudgetDatabase.createViewModel(sync: BudgetSyncController = TestSyncController()) =
     ListTagsViewModel(SavedStateHandle(), TagsDao(this), sync)
+
+  private class FailingSyncController : BudgetSyncController {
+    override suspend fun syncChanges(changes: List<LocalChange>): Unit = error("sync failed")
+
+    override fun schedule() = Unit
+  }
 }

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -2,7 +2,10 @@ package aktual.budget.tags.vm.list
 
 import aktual.budget.db.BudgetDatabase
 import aktual.budget.db.dao.TagsDao
+import aktual.budget.model.BudgetSyncController
+import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
+import aktual.budget.tags.vm.RecordingSyncController
 import aktual.budget.tags.vm.insertTag
 import aktual.test.runDatabaseTest
 import androidx.compose.ui.graphics.Color
@@ -101,6 +104,43 @@ class ListTagsViewModelTest {
     }
   }
 
-  private fun BudgetDatabase.createViewModel() =
-    ListTagsViewModel(SavedStateHandle(), TagsDao(this))
+  @Test
+  fun `Delete tombstones the tag, removes it, and emits an event`() = runDatabaseTest {
+    insertTag(id = "groceries-id", tag = "groceries")
+    insertTag(id = "rent-id", tag = "rent")
+
+    val sync = RecordingSyncController()
+    val viewModel = createViewModel(sync)
+
+    // wait for the initial load with both tags
+    viewModel.state.test {
+      assertThat(awaitItem()).isInstanceOf(Success::class).prop(Success::tags).hasSize(2)
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    // deleting one tag emits a confirmation event for it
+    viewModel.events.test {
+      viewModel.delete(TagId("groceries-id"))
+      assertThat(awaitItem()).isEqualTo(ListTagsEvent.Deleted("groceries"))
+    }
+
+    // a tombstone change was queued for sync
+    assertThat(sync.changes)
+      .extracting(LocalChange::row, LocalChange::column)
+      .containsExactly("groceries-id" to "tombstone")
+
+    // and only the remaining tag is shown
+    viewModel.state.test {
+      assertThat(awaitItem())
+        .isInstanceOf(Success::class)
+        .prop(Success::tags)
+        .extracting(TagItem::tag)
+        .containsExactly("rent")
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  private fun BudgetDatabase.createViewModel(
+    sync: BudgetSyncController = RecordingSyncController()
+  ) = ListTagsViewModel(SavedStateHandle(), TagsDao(this), sync)
 }

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -5,8 +5,8 @@ import aktual.budget.db.dao.TagsDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
 import aktual.budget.model.TagId
-import aktual.budget.tags.vm.RecordingSyncController
 import aktual.budget.tags.vm.insertTag
+import aktual.test.TestSyncController
 import aktual.test.runDatabaseTest
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.SavedStateHandle
@@ -109,7 +109,7 @@ class ListTagsViewModelTest {
     insertTag(id = "groceries-id", tag = "groceries")
     insertTag(id = "rent-id", tag = "rent")
 
-    val sync = RecordingSyncController()
+    val sync = TestSyncController()
     val viewModel = createViewModel(sync)
 
     // wait for the initial load with both tags
@@ -140,7 +140,6 @@ class ListTagsViewModelTest {
     }
   }
 
-  private fun BudgetDatabase.createViewModel(
-    sync: BudgetSyncController = RecordingSyncController()
-  ) = ListTagsViewModel(SavedStateHandle(), TagsDao(this), sync)
+  private fun BudgetDatabase.createViewModel(sync: BudgetSyncController = TestSyncController()) =
+    ListTagsViewModel(SavedStateHandle(), TagsDao(this), sync)
 }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -57,7 +57,7 @@ class EditTagViewModel(
   private val mutableColor = MutableStateFlow<Color?>(null)
   private val mutableColorError = MutableStateFlow(false)
 
-  // non-null when the last save attempt failed; drives an error dialog so the user isn't left
+  // the reason the last save attempt failed, shown in an error dialog so the user isn't left
   // guessing
   private val mutableSaveError = MutableStateFlow<String?>(null)
   val saveError: StateFlow<String?> = mutableSaveError.asStateFlow()

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsEvent.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsEvent.kt
@@ -6,4 +6,7 @@ import androidx.compose.runtime.Immutable
 sealed interface ListTagsEvent {
   // the tombstoned tag's name, so the UI can show a confirmation toast
   @JvmInline value class Deleted(val tag: String) : ListTagsEvent
+
+  // a delete attempt failed — tag is the name if we knew it, null otherwise
+  @JvmInline value class DeleteFailed(val tag: String?) : ListTagsEvent
 }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsEvent.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsEvent.kt
@@ -1,0 +1,9 @@
+package aktual.budget.tags.vm.list
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+sealed interface ListTagsEvent {
+  // the tombstoned tag's name, so the UI can show a confirmation toast
+  @JvmInline value class Deleted(val tag: String) : ListTagsEvent
+}

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
@@ -1,6 +1,10 @@
 package aktual.budget.tags.vm.list
 
+import aktual.budget.db.dao.DatabaseTables.TAGS
 import aktual.budget.db.dao.TagsDao
+import aktual.budget.model.BudgetSyncController
+import aktual.budget.model.TagId
+import aktual.budget.model.tombstone
 import aktual.di.BudgetScope
 import alakazam.kotlin.requireMessage
 import androidx.compose.runtime.Stable
@@ -24,8 +28,12 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import logcat.logcat
@@ -35,6 +43,7 @@ import logcat.logcat
 class ListTagsViewModel(
   @Assisted private val savedState: SavedStateHandle,
   private val tagsDao: TagsDao,
+  private val syncController: BudgetSyncController,
 ) : ViewModel() {
   @AssistedFactory
   @ViewModelAssistedFactoryKey(ListTagsViewModel::class)
@@ -53,6 +62,14 @@ class ListTagsViewModel(
 
   private val filterText = savedState.getStateFlow(KEY_FILTER_TEXT, initialValue = "")
   private val isSearchActive = savedState.getStateFlow(KEY_IS_SEARCH_ACTIVE, initialValue = false)
+
+  private val mutableEvents =
+    MutableSharedFlow<ListTagsEvent>(
+      replay = 0,
+      extraBufferCapacity = 1,
+      onBufferOverflow = DROP_OLDEST,
+    )
+  val events: SharedFlow<ListTagsEvent> = mutableEvents.asSharedFlow()
 
   val state: StateFlow<ListTagsState> =
     viewModelScope.launchMolecule(Immediate) {
@@ -103,6 +120,26 @@ class ListTagsViewModel(
         logcat.e(e) { "Failed loading tags" }
         mutableFailure.update { e.requireMessage() }
         mutableIsLoading.update { false }
+      }
+    }
+  }
+
+  fun delete(id: TagId) {
+    viewModelScope.launch {
+      val name = mutableTags.value.firstOrNull { it.id == id }?.tag
+      try {
+        // syncChanges applies the tombstone to the local db and queues it for sync
+        syncController.syncChanges(tombstone(dataset = TAGS, row = id.toString()))
+        // optimistically drop the row so it animates out without a loading flash
+        mutableTags.update { tags -> tags.filterNot { it.id == id }.toImmutableList() }
+        if (name != null) {
+          mutableEvents.tryEmit(ListTagsEvent.Deleted(name))
+        }
+        logcat.d { "Tombstoned tag $id" }
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        logcat.e(e) { "Failed deleting tag $id" }
       }
     }
   }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
@@ -104,8 +104,12 @@ class ListTagsViewModel(
     savedState[KEY_IS_SEARCH_ACTIVE] = false
   }
 
-  fun reload() {
-    mutableIsLoading.update { true }
+  // showLoading = false does a silent refresh (no loading screen), used when returning to the
+  // list after editing a tag elsewhere
+  fun reload(showLoading: Boolean = true) {
+    if (showLoading) {
+      mutableIsLoading.update { true }
+    }
     reloadJob?.cancel()
     reloadJob = viewModelScope.launch {
       try {
@@ -140,6 +144,7 @@ class ListTagsViewModel(
         throw e
       } catch (e: Exception) {
         logcat.e(e) { "Failed deleting tag $id" }
+        mutableEvents.tryEmit(ListTagsEvent.DeleteFailed(name))
       }
     }
   }

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -9,6 +9,8 @@
   <string name="tags_filter_placeholder">Filter tags…</string>
   <string name="tags_filter_clear">Clear filter</string>
   <string name="tags_create">Create tag</string>
+  <string name="tags_delete">Delete</string>
+  <string name="tags_deleted">Deleted #%1$s</string>
   <string name="tags_create_title">New tag</string>
   <string name="tags_edit_title">Edit tag</string>
   <string name="tags_create_tag_label">Tag</string>

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -11,6 +11,8 @@
   <string name="tags_create">Create tag</string>
   <string name="tags_delete">Delete</string>
   <string name="tags_deleted">Deleted #%1$s</string>
+  <string name="tags_delete_failed">Couldn\'t delete #%1$s</string>
+  <string name="tags_delete_failed_unknown">Couldn\'t delete tag</string>
   <string name="tags_create_title">New tag</string>
   <string name="tags_edit_title">Edit tag</string>
   <string name="tags_create_tag_label">Tag</string>

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -23,7 +23,6 @@
   <string name="tags_create_color_invalid">Invalid color code</string>
   <string name="tags_create_save">Save</string>
   <string name="tags_save_failure_title">Couldn\'t save tag</string>
-  <string name="tags_save_failure_message">Something went wrong while saving. Please try again.</string>
   <string name="tags_save_failure_dismiss">OK</string>
   <string name="tags_edit_failure_prefix">Failed loading tag</string>
   <string name="tags_edit_not_found">This tag no longer exists</string>

--- a/aktual-test/src/commonMain/kotlin/aktual/test/TestSyncController.kt
+++ b/aktual-test/src/commonMain/kotlin/aktual/test/TestSyncController.kt
@@ -1,0 +1,14 @@
+package aktual.test
+
+import aktual.budget.model.BudgetSyncController
+import aktual.budget.model.LocalChange
+
+class TestSyncController : BudgetSyncController {
+  val changes = mutableListOf<LocalChange>()
+
+  override suspend fun syncChanges(changes: List<LocalChange>) {
+    this.changes += changes
+  }
+
+  override fun schedule() = Unit
+}


### PR DESCRIPTION
## Summary

Adds swipe-to-delete for tags in the tag list. Swiping a row left reveals a red delete
button; tapping it tombstones the tag (via sync) and shows a confirmation snackbar. Only
one row can be open at a time — starting to swipe another row immediately closes the
previously open one.

## Changes

- **Swipe-to-reveal row** (`TagItem`): the row sits over a red delete button anchored to
  the end, offset by an `AnchoredDraggableState` (`Closed`/`Open` anchors). A
  `MutableInteractionSource` detects `DragInteraction.Start` so the open row closes the
  instant another row begins swiping, rather than waiting for the drag to settle.
- **VM** (`ListTagsViewModel.delete`): tombstones via
  `syncController.syncChanges(tombstone(TAGS, id))` (applies locally + queues sync,
  mirroring the rules pattern), optimistically drops the row so it animates out, and emits
  a `ListTagsEvent.Deleted(name)`.
- **Toast** (`ListTagsScreen`): collects `events` and shows a snackbar ("Deleted #…").
- **Strings**: added `tags_delete` and `tags_deleted`.
- **Tests**: added a delete test to `ListTagsViewModelTest`; extracted the shared
  `TestSyncController` test fake.
- **Tooling**: tightened the `gradle-runner` agent definition to report every requested
  command's outcome and to flag ambiguous task names.

## Testing

- `:aktual-budget:tags:vm:compileAll` / `:aktual-budget:tags:ui:compileAll` — pass
- `:aktual-budget:tags:vm:testAndroidHostTest` (ListTags + EditTag) — 15 tests pass
