### PR TITLE
Externalize global-trigger patterns into a gitignore-format list

### DIFF
--- a/scripts/lib/.global-triggers
+++ b/scripts/lib/.global-triggers
@@ -1,0 +1,10 @@
+/.editorconfig
+/.github/
+/.java-version
+/build-logic/
+/build.gradle.kts
+/config/
+/detekt-rules/
+/gradle.properties
+/gradle/
+/settings.gradle.kts

--- a/scripts/lib/modules.sh
+++ b/scripts/lib/modules.sh
@@ -12,10 +12,25 @@ all_gradle_modules() {
   grep -oP '":aktual[^"]*' settings.gradle.kts | tr -d '"' | sort
 }
 
-# Regex of repo-root-relative paths that, when changed, affect every module and so should
-# trigger a run across all of them: the root build file, anything under .github/ or
-# build-logic/, and the version catalog.
-GLOBAL_TRIGGER_RE='^build\.gradle\.kts$|^\.github/|^build-logic/|(^|/)libs\.versions\.toml$'
+# List of repo-root-relative patterns (in .gitignore syntax) that, when changed, affect
+# every module and so should trigger a run across all of them.
+GITIGNORE_TRIGGERS="$MODULES_LIB_DIR/.global-triggers"
+
+# Return 0 if any of the newline-separated paths on stdin match a pattern in
+# .global-triggers. Matching is delegated to `git check-ignore` against a throwaway
+# repo whose only ignore source is that file, so the repo's own .gitignore can't interfere.
+matches_gitignore_triggers() {
+  [[ -f "$GITIGNORE_TRIGGERS" ]] || return 1
+  local tmp rc=1
+  tmp="$(mktemp -d)"
+  git init -q "$tmp"
+  cp "$GITIGNORE_TRIGGERS" "$tmp/.gitignore"
+  if git -C "$tmp" -c core.excludesFile=/dev/null check-ignore --no-index --quiet --stdin; then
+    rc=0
+  fi
+  rm -rf "$tmp"
+  return "$rc"
+}
 
 # Print the Gradle module paths (e.g. :aktual-core:ui) that own the given changed files.
 # Reads module paths from settings.gradle.kts in the current working directory.
@@ -79,7 +94,7 @@ run_changed_module_task() {
   fi
 
   local modules
-  if echo "$changed_files" | grep -qE "$GLOBAL_TRIGGER_RE"; then
+  if printf '%s\n' "$changed_files" | matches_gitignore_triggers; then
     echo "Build/config files changed since $base_branch ($merge_base_short) — running on all modules."
     modules=$(all_gradle_modules)
   else


### PR DESCRIPTION
## What

The set of repo-root files that force a per-module Gradle task to run on **all** modules — rather than just the modules with changed files — used to live as a hardcoded extended-regex string (`GLOBAL_TRIGGER_RE`) inside `scripts/lib/modules.sh`.

This moves that set out into `scripts/lib/.global-triggers`, written in **`.gitignore` syntax**:

```
/build.gradle.kts
/settings.gradle.kts
/gradle.properties
/.java-version
/.github/
/build-logic/
/gradle/
/detekt-rules/
/config/
/.editorconfig
```

Matching is delegated to `git check-ignore`, run against a throwaway repo whose only ignore source is this file, so the project's own `.gitignore` can't interfere. That gives exact gitignore semantics: leading `/` anchors to repo root, trailing `/` matches a directory and its contents, plus `*`/`**`/`!`.

## Why

- Editing the trigger set no longer means touching shell code.
- gitignore is a more familiar syntax than raw ERE.
- The list also grew while here: `settings.gradle.kts`, `gradle.properties`, `.java-version`, all of `gradle/` (wrapper, repositories, robolectric), `detekt-rules/`, `config/`, and `.editorconfig` are now triggers — previously only the root build file, `.github/`, `build-logic/`, and the version catalog were.

Consumed by `lint.sh`, `test.sh`, and `detekt.sh` via the shared `matches_gitignore_triggers` helper. `/build.gradle.kts` still anchors to the root file only (a module's own `build.gradle.kts` does not trigger a global run), matching the old regex behaviour.

## Note

Each invocation does a `git init` in a tempdir (a few ms), once per script call — negligible.