### PR TITLE
Hide preview in app switcher

### DIFF
--- a/aktual-app/android/src/main/kotlin/aktual/app/android/AktualActivity.kt
+++ b/aktual-app/android/src/main/kotlin/aktual/app/android/AktualActivity.kt
@@ -7,6 +7,7 @@ import aktual.di.AppScope
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
@@ -19,10 +20,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+import kotlinx.coroutines.launch
 
 @ActivityKey
 @ContributesIntoMap(AppScope::class, binding<Activity>())
@@ -44,6 +49,21 @@ class AktualActivity(override val defaultViewModelProviderFactory: MetroViewMode
       statusBarStyle = SystemBarStyle.auto(transparent, transparent),
       navigationBarStyle = SystemBarStyle.auto(transparent, transparent),
     )
+
+    // toggle FLAG_SECURE so the app's contents are hidden in the recents switcher (and screenshots
+    // are blocked) according to the user's preference. The flow seeds with the default (true), so
+    // we're secure-by-default until DataStore reports otherwise
+    lifecycleScope.launch {
+      repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.hidePreviewInAppSwitcher.collect { hide ->
+          if (hide) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+          } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+          }
+        }
+      }
+    }
 
     setContent { Content(viewModel) }
   }

--- a/aktual-app/android/src/main/kotlin/aktual/app/android/AktualActivityViewModel.kt
+++ b/aktual-app/android/src/main/kotlin/aktual/app/android/AktualActivityViewModel.kt
@@ -10,11 +10,15 @@ import aktual.core.nav.NavEntryContributor
 import aktual.core.theme.ThemeResolver
 import aktual.di.AppScope
 import aktual.di.RunLevelState
+import aktual.prefs.SystemUiPreferences
+import aktual.prefs.asStateFlow
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import kotlinx.coroutines.flow.StateFlow
 
 @Stable
 @ViewModelKey
@@ -27,6 +31,7 @@ class AktualActivityViewModel(
   blurConfigUseCase: BlurConfigUseCase,
   initialRouteUseCase: InitialRouteUseCase,
   bottomBarStateUseCase: BottomBarStateUseCase,
+  systemUiPreferences: SystemUiPreferences,
   val runLevels: RunLevelState,
 ) :
   RootViewModel(
@@ -38,4 +43,8 @@ class AktualActivityViewModel(
     initialRouteUseCase = initialRouteUseCase,
     bottomBarStateUseCase = bottomBarStateUseCase,
     runLevels = runLevels,
-  )
+  ) {
+  // hides the app's contents in the recent-apps switcher (and blocks screenshots) when true
+  val hidePreviewInAppSwitcher: StateFlow<Boolean> =
+    systemUiPreferences.hidePreviewInAppSwitcher.asStateFlow(viewModelScope)
+}

--- a/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/MaterialIconPreviews.kt
+++ b/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/MaterialIconPreviews.kt
@@ -70,6 +70,7 @@ private val materialIcons =
       SaveAs,
       Search,
       SearchOff,
+      Security,
       SelectAll,
       Settings,
       Sort,

--- a/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/Security.kt
+++ b/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/Security.kt
@@ -1,0 +1,31 @@
+@file:Suppress("UnusedReceiverParameter")
+
+package aktual.core.icons.material
+
+import aktual.core.icons.material.internal.materialIcon
+import aktual.core.icons.material.internal.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val MaterialIcons.Security: ImageVector by lazy {
+  materialIcon(name = "Security") {
+    materialPath {
+      moveTo(12.0f, 1.0f)
+      lineTo(3.0f, 5.0f)
+      verticalLineToRelative(6.0f)
+      curveToRelative(0.0f, 5.55f, 3.84f, 10.74f, 9.0f, 12.0f)
+      curveToRelative(5.16f, -1.26f, 9.0f, -6.45f, 9.0f, -12.0f)
+      lineTo(21.0f, 5.0f)
+      lineToRelative(-9.0f, -4.0f)
+      close()
+      moveTo(12.0f, 11.99f)
+      horizontalLineToRelative(7.0f)
+      curveToRelative(-0.53f, 4.12f, -3.28f, 7.79f, -7.0f, 8.94f)
+      lineTo(12.0f, 12.0f)
+      lineTo(5.0f, 12.0f)
+      lineTo(5.0f, 6.3f)
+      lineToRelative(7.0f, -3.11f)
+      verticalLineToRelative(8.8f)
+      close()
+    }
+  }
+}

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-settings.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-settings.xml
@@ -59,4 +59,6 @@
   <string name="settings_ui_blur_dialogs">Blur behind dialogs</string>
   <string name="settings_ui_blur_radius">Blur radius</string>
   <string name="settings_ui_blur_alpha">Blur alpha</string>
+  <string name="settings_ui_hide_preview">Hide preview in app switcher</string>
+  <string name="settings_ui_hide_preview_desc">Hide app contents in the recents screen. Also blocks screenshots and screen recording.</string>
 </resources>

--- a/aktual-prefs/impl/src/commonMain/kotlin/aktual/prefs/SystemUiPreferencesImpl.kt
+++ b/aktual-prefs/impl/src/commonMain/kotlin/aktual/prefs/SystemUiPreferencesImpl.kt
@@ -23,4 +23,9 @@ class SystemUiPreferencesImpl(dataStore: DataStore<Preferences>) : SystemUiPrefe
 
   override val blurAlpha: Preference<Float> =
     dataStore.float(key = floatPreferencesKey("blurAlpha"), default = 0.35f).required()
+
+  override val hidePreviewInAppSwitcher: Preference<Boolean> =
+    dataStore
+      .boolean(key = booleanPreferencesKey("hidePreviewInAppSwitcher"), default = true)
+      .required()
 }

--- a/aktual-prefs/src/commonMain/kotlin/aktual/prefs/SystemUiPreferences.kt
+++ b/aktual-prefs/src/commonMain/kotlin/aktual/prefs/SystemUiPreferences.kt
@@ -6,4 +6,5 @@ interface SystemUiPreferences {
   val blurDialogs: Preference<Boolean>
   val blurRadius: Preference<Float>
   val blurAlpha: Preference<Float>
+  val hidePreviewInAppSwitcher: Preference<Boolean>
 }

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/BooleanPreferenceItem.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/BooleanPreferenceItem.kt
@@ -28,6 +28,7 @@ internal fun BooleanPreferenceItem(
   includeBackground: Boolean = true,
   bottomContent: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
+  if (!preference.visible) return
   BooleanPreferenceItem(
     value = preference.value,
     onValueChange = preference.onChange,

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/ListPreferenceItem.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/ListPreferenceItem.kt
@@ -41,6 +41,7 @@ internal fun <E : Enum<E>> ListPreferenceItem(
   modifier: Modifier = Modifier,
   includeBackground: Boolean = true,
 ) {
+  if (!preference.visible) return
   ListPreferenceItem(
     value = preference.value,
     options = preference.options,

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/SliderPreferenceItem.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/SliderPreferenceItem.kt
@@ -40,6 +40,7 @@ internal fun SliderPreferenceItem(
   modifier: Modifier = Modifier,
   includeBackground: Boolean = true,
 ) {
+  if (!preference.visible) return
   SliderPreferenceItem(
     value = preference.value,
     range = preference.range,

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/root/SettingsScreen.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/root/SettingsScreen.kt
@@ -135,6 +135,7 @@ private fun PreviewSettingsScaffold(@PreviewParameter(ColoredParameters::class) 
               blurDialogs = BooleanPreference(true),
               blurRadiusDp = BlurRadiusPreference(5f),
               blurAlpha = BlurAlphaPreference(0.5f),
+              hidePreviewInAppSwitcher = BooleanPreference(true),
             ),
           format =
             FormatConfigState(

--- a/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/root/SystemUiGroup.kt
+++ b/aktual-prefs/ui/src/commonMain/kotlin/aktual/prefs/ui/root/SystemUiGroup.kt
@@ -4,6 +4,7 @@ import aktual.core.icons.material.BlurOn
 import aktual.core.icons.material.Dialogs
 import aktual.core.icons.material.LinearScale
 import aktual.core.icons.material.MaterialIcons
+import aktual.core.icons.material.Security
 import aktual.core.icons.material.TransitionDissolve
 import aktual.core.icons.material.Visibility
 import aktual.core.icons.material.VisibilityOff
@@ -60,6 +61,14 @@ internal fun SystemUiGroup(state: SystemUiConfigState, modifier: Modifier = Modi
       title = Strings.settingsUiBlurAlpha,
       subtitle = null,
       icon = MaterialIcons.TransitionDissolve,
+      includeBackground = false,
+    )
+
+    BooleanPreferenceItem(
+      preference = state.hidePreviewInAppSwitcher,
+      title = Strings.settingsUiHidePreview,
+      subtitle = Strings.settingsUiHidePreviewDesc,
+      icon = MaterialIcons.Security,
       includeBackground = false,
     )
   }

--- a/aktual-prefs/vm/src/androidMain/kotlin/aktual/prefs/vm/root/ShouldShowPreference.android.kt
+++ b/aktual-prefs/vm/src/androidMain/kotlin/aktual/prefs/vm/root/ShouldShowPreference.android.kt
@@ -1,0 +1,3 @@
+package aktual.prefs.vm.root
+
+internal actual val ShouldShowHidePreviewInAppSwitcher = true

--- a/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/SharedModels.kt
+++ b/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/SharedModels.kt
@@ -8,6 +8,7 @@ import kotlinx.collections.immutable.toImmutableList
 data class BooleanPreference(
   val value: Boolean,
   val enabled: Boolean = true,
+  val visible: Boolean = true,
   val onChange: (Boolean) -> Unit = {},
 )
 
@@ -16,18 +17,21 @@ data class ListPreference<T : Any>(
   val value: T,
   val options: ImmutableList<T>,
   val enabled: Boolean = true,
+  val visible: Boolean = true,
   val onChange: (T) -> Unit = {},
 )
 
 inline fun <reified E : Enum<E>> ListPreference(
   value: E,
   enabled: Boolean = true,
+  visible: Boolean = true,
   noinline onChange: (E) -> Unit = {},
 ): ListPreference<E> =
   ListPreference(
     value = value,
     options = enumValues<E>().toImmutableList(),
     enabled = enabled,
+    visible = visible,
     onChange = onChange,
   )
 
@@ -36,5 +40,6 @@ data class SliderPreference(
   val value: Float,
   val range: ClosedFloatingPointRange<Float>,
   val enabled: Boolean = true,
+  val visible: Boolean = true,
   val onChange: (Float) -> Unit = {},
 )

--- a/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/root/SettingsScreenState.kt
+++ b/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/root/SettingsScreenState.kt
@@ -24,6 +24,7 @@ data class SystemUiConfigState(
   val blurDialogs: BooleanPreference,
   val blurRadiusDp: SliderPreference,
   val blurAlpha: SliderPreference,
+  val hidePreviewInAppSwitcher: BooleanPreference,
 )
 
 fun BlurRadiusPreference(

--- a/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/root/SettingsViewModel.kt
+++ b/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/root/SettingsViewModel.kt
@@ -48,6 +48,8 @@ class SettingsViewModel(
     val blurDialogs by systemUiPreferences.blurDialogs.collectAsStateFlow()
     val blurRadius by systemUiPreferences.blurRadius.collectAsStateFlow()
     val blurAlpha by systemUiPreferences.blurAlpha.collectAsStateFlow()
+    val hidePreviewInAppSwitcher by
+      systemUiPreferences.hidePreviewInAppSwitcher.collectAsStateFlow()
     val anyBlurEnabled = blurAppBars || blurDialogs
     return SystemUiConfigState(
       showStatusBar =
@@ -76,6 +78,12 @@ class SettingsViewModel(
           value = blurAlpha,
           enabled = anyBlurEnabled,
           onChange = { systemUiPreferences.blurAlpha.launchAndSet(it) },
+        ),
+      hidePreviewInAppSwitcher =
+        BooleanPreference(
+          value = hidePreviewInAppSwitcher,
+          visible = ShouldShowHidePreviewInAppSwitcher,
+          onChange = { systemUiPreferences.hidePreviewInAppSwitcher.launchAndSet(it) },
         ),
     )
   }

--- a/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/root/ShouldShowPreference.kt
+++ b/aktual-prefs/vm/src/commonMain/kotlin/aktual/prefs/vm/root/ShouldShowPreference.kt
@@ -1,0 +1,3 @@
+package aktual.prefs.vm.root
+
+internal expect val ShouldShowHidePreviewInAppSwitcher: Boolean

--- a/aktual-prefs/vm/src/desktopMain/kotlin/aktual/prefs/vm/root/ShouldShowPreference.desktop.kt
+++ b/aktual-prefs/vm/src/desktopMain/kotlin/aktual/prefs/vm/root/ShouldShowPreference.desktop.kt
@@ -1,0 +1,3 @@
+package aktual.prefs.vm.root
+
+internal actual val ShouldShowHidePreviewInAppSwitcher = false


### PR DESCRIPTION
Configurable System UI toggle (default on) applying `FLAG_SECURE` to the Android window, hiding app contents in the recents switcher and blocking screenshots. Hidden on desktop, where it has no equivalent.

Closes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)