### PR TITLE
Fix crash when switching budget or re-logging in

### DIFF
--- a/aktual-di/runlevel/impl/src/commonMain/kotlin/aktual/di/RunLevelStateHolder.kt
+++ b/aktual-di/runlevel/impl/src/commonMain/kotlin/aktual/di/RunLevelStateHolder.kt
@@ -62,14 +62,20 @@ class RunLevelStateHolder(private val driverFactory: SqlDriverFactory) :
   override fun onServerChosen(url: ServerUrl): ServerChosenGraph {
     val serverChosenGraph = value[AppGraph::class].serverChosenGraphFactory.create(url)
     serverChosenGraph.initialize()
-    update { levels -> (levels + serverChosenGraph).also(::assertAllDistinct).sorted() }
+    // Replace any existing server-chosen level (and everything below it) so re-entering this level
+    // - e.g. logging out and back in - doesn't stack a second graph of the same type
+    update { levels ->
+      (levels.popTo<AppGraph>() + serverChosenGraph).also(::assertAllDistinct).sorted()
+    }
     return serverChosenGraph
   }
 
   override fun onLoggedIn(token: Token): LoggedInGraph {
     val loggedInGraph = value[ServerChosenGraph::class].loggedInGraphFactory.create(token)
     loggedInGraph.initialize()
-    update { levels -> (levels + loggedInGraph).also(::assertAllDistinct).sorted() }
+    update { levels ->
+      (levels.popTo<ServerChosenGraph>() + loggedInGraph).also(::assertAllDistinct).sorted()
+    }
     return loggedInGraph
   }
 
@@ -80,7 +86,10 @@ class RunLevelStateHolder(private val driverFactory: SqlDriverFactory) :
         .budgetGraphFactory
         .create(id = metadata.cloudFileId, metadata, driver)
     budgetGraph.initialize()
-    update { levels -> (levels + budgetGraph).also(::assertAllDistinct).sorted() }
+    // Replace any currently-open budget so switching budgets doesn't stack a second BudgetGraph
+    update { levels ->
+      (levels.popTo<LoggedInGraph>() + budgetGraph).also(::assertAllDistinct).sorted()
+    }
     return budgetGraph
   }
 

--- a/aktual-test/smoke/src/commonTest/kotlin/aktual/test/TestUtils.kt
+++ b/aktual-test/smoke/src/commonTest/kotlin/aktual/test/TestUtils.kt
@@ -16,3 +16,8 @@ internal val BUDGET_ID = BudgetId("abc-123")
 internal val TRANSACTIONS_SPEC = TransactionsSpec(AccountSpec.AllAccounts)
 
 internal val DB_METADATA = DbMetadata(budgetName = "My Budget", cloudFileId = BUDGET_ID)
+
+internal val SECOND_BUDGET_ID = BudgetId("def-456")
+
+internal val SECOND_DB_METADATA =
+  DbMetadata(budgetName = "Other Budget", cloudFileId = SECOND_BUDGET_ID)

--- a/aktual-test/smoke/src/desktopTest/kotlin/aktual/test/RunLevelTransitionTest.kt
+++ b/aktual-test/smoke/src/desktopTest/kotlin/aktual/test/RunLevelTransitionTest.kt
@@ -1,0 +1,83 @@
+package aktual.test
+
+import aktual.di.BudgetGraph
+import aktual.di.LoggedInGraph
+import aktual.di.ServerChosenGraph
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import dev.zacsweers.metro.createDynamicGraph
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import logcat.LogcatLogger
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+
+// Regression coverage for #1336, where switching budget / re-logging in stacked duplicate run-level
+// graphs
+class RunLevelTransitionTest {
+  private lateinit var rootDir: Path
+  private lateinit var appGraph: TestJvmAppGraph
+
+  @BeforeTest
+  fun before() {
+    rootDir = createTempDirectory().toOkioPath()
+    appGraph =
+      createDynamicGraph<TestJvmAppGraph>(
+        TestAppDirectoryContainer(rootDir),
+        TestBudgetFilesContainer(rootDir),
+      )
+    with(appGraph.runLevelController) {
+      init(listOf(appGraph))
+      onServerChosen(SERVER_URL)
+      onLoggedIn(LOGIN_TOKEN)
+      onBudget(DB_METADATA)
+    }
+  }
+
+  @AfterTest
+  fun after() {
+    LogcatLogger.uninstall()
+    appGraph.close()
+    FileSystem.SYSTEM.deleteRecursively(rootDir)
+  }
+
+  // Switching budget opened a second budget while the first was still open, stacking two
+  // BudgetGraphs and tripping assertAllDistinct
+  @Test
+  fun switchingBudgetKeepsSingleBudgetLevel() = runTest {
+    appGraph.runLevelState.all().test {
+      assertEmissionSize(4) // app, server-chosen, logged-in, budget A
+
+      appGraph.runLevelController.onBudget(SECOND_DB_METADATA)
+
+      val levels = awaitItem()
+      assertThat(levels).hasSize(4)
+      assertThat(levels.filterIsInstance<BudgetGraph>()).hasSize(1)
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  // Logging out from a budget then back in re-entered the server-chosen level without first popping
+  // the open budget/logged-in levels, stacking a second ServerChosenGraph
+  @Test
+  fun reChoosingServerCollapsesToSingleServerChosenLevel() = runTest {
+    appGraph.runLevelState.all().test {
+      assertEmissionSize(4) // app, server-chosen, logged-in, budget
+
+      appGraph.runLevelController.onServerChosen(SERVER_URL)
+
+      val levels = awaitItem()
+      assertThat(levels).hasSize(2) // collapsed back to app, server-chosen
+      assertThat(levels.filterIsInstance<ServerChosenGraph>()).hasSize(1)
+      assertThat(levels.filterIsInstance<LoggedInGraph>()).isEmpty()
+      assertThat(levels.filterIsInstance<BudgetGraph>()).isEmpty()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+}


### PR DESCRIPTION
Switching budget, or logging out from a budget then back in, crashed with `IllegalArgumentException: Found multiple run levels of the same type`.

The navrail Switch/Log out actions only navigate — they don't pop the run-level stack — so `onBudget`/`onServerChosen` then appended a second graph of a level that was already present, tripping `assertAllDistinct`.

Fix: make the run-level transitions idempotent. `onServerChosen`/`onLoggedIn`/`onBudget` now pop their own level (and everything below, closing those graphs) before adding the new one, so re-entering a level replaces it rather than stacking a duplicate.

Adds `RunLevelTransitionTest` (desktop, observes the run-level `StateFlow` via Turbine) covering both reported scenarios.

Closes #1336