### PR TITLE
Fix UNIQUE crash when renaming a tag onto a deleted tag's name

### DIFF
--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -18,6 +18,7 @@ import app.cash.turbine.test
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
@@ -230,6 +231,39 @@ class EditTagViewModelTest {
       // the old row's id is reused rather than the freshly generated uuid
       assertThat(tagsDao.getTagIdByName("groceries")).isEqualTo(TagId("old-id"))
       assertThat(sync.changes.map(LocalChange::row).distinct()).containsExactly("old-id")
+    }
+
+  @Test
+  fun `Renaming a tag onto a tombstoned name resurrects the old row and retires the edited one`() =
+    runDatabaseTest {
+      insertTag(id = "old-id", tag = "groceries")
+      // tombstone "groceries", as a delete-sync would, so it still owns the UNIQUE name
+      tombstoneTag("old-id")
+      insertTag(id = "food-id", tag = "food")
+
+      val sync = TestSyncController()
+      val viewModel = createViewModel(id = TagId("food-id"), sync = sync)
+      viewModel.awaitLoaded()
+
+      // renaming onto the deleted name must not trip the UNIQUE(tag) constraint — before the fix
+      // this insert threw and save() surfaced an error instead of finishing. FinishedSaving is only
+      // emitted on the happy path, so receiving it proves the save succeeded
+      viewModel.setTag("groceries")
+      viewModel.setDescription("Weekly food shopping")
+
+      viewModel.events.test {
+        viewModel.save()
+        assertThatNextEmission().isEqualTo(EditTagEvent.FinishedSaving)
+      }
+
+      // the name now resolves to the resurrected row rather than the one we were editing
+      assertThat(tagsDao.getTagIdByName("groceries")).isEqualTo(TagId("old-id"))
+
+      // the sync log retires the edited row and rewrites the deleted one under its original id
+      assertThat(sync.changes.map(LocalChange::row).distinct())
+        .containsExactlyInAnyOrder("food-id", "old-id")
+      assertThat(sync.changes.filter { it.row == "food-id" }.map(LocalChange::column))
+        .containsExactly("tombstone")
     }
 
   @Test

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -235,7 +235,7 @@ class EditTagViewModelTest {
 
   @Test
   fun `Renaming a tag onto a tombstoned name resurrects the old row and retires the edited one`() =
-    runDatabaseTest {
+    runDatabaseTest { _ ->
       insertTag(id = "old-id", tag = "groceries")
       // tombstone "groceries", as a delete-sync would, so it still owns the UNIQUE name
       tombstoneTag("old-id")

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -5,6 +5,7 @@ import aktual.budget.db.GetTag
 import aktual.budget.db.dao.TagsDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
+import aktual.budget.model.MessageValue
 import aktual.budget.model.TagId
 import aktual.budget.tags.vm.insertTag
 import aktual.budget.tags.vm.tombstoneTag
@@ -264,6 +265,15 @@ class EditTagViewModelTest {
         .containsExactlyInAnyOrder("food-id", "old-id")
       assertThat(sync.changes.filter { it.row == "food-id" }.map(LocalChange::column))
         .containsExactly("tombstone")
+      // the resurrected row gets a full insert — the edits must not be dropped, and tombstone is
+      // cleared to bring it back
+      assertThat(sync.changes.filter { it.row == "old-id" }.map(LocalChange::column))
+        .containsExactlyInAnyOrder("id", "tag", "color", "description", "tombstone")
+      val oldIdChanges = sync.changes.filter { it.row == "old-id" }.associateBy(LocalChange::column)
+      assertThat(oldIdChanges["tag"]?.value).isEqualTo(MessageValue.String("groceries"))
+      assertThat(oldIdChanges["description"]?.value)
+        .isEqualTo(MessageValue.String("Weekly food shopping"))
+      assertThat(oldIdChanges["tombstone"]?.value).isEqualTo(MessageValue.Number(0))
     }
 
   @Test

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -208,8 +208,9 @@ class EditTagViewModel(
         // for tombstoned rows, so a non-null owner that getTag can't see is a deleted tag still
         // squatting on the name. Only the rename path needs the extra lookup, so skip it on create
         val owner = tagsDao.getTagIdByName(tag)
-        val tombstonedOwner =
-          tagId?.let { id -> owner?.takeIf { it != id && tagsDao.getTag(it) == null } }
+        val tombstonedOwner = tagId?.let { id ->
+          owner?.takeIf { it != id && tagsDao.getTag(it) == null }
+        }
 
         if (tagId != null && tombstonedOwner != null) {
           // renaming onto a deleted tag's name: writing the name onto our row would trip the

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -8,8 +8,8 @@ import aktual.budget.model.MessageValue
 import aktual.budget.model.TagId
 import aktual.budget.model.messageValue
 import aktual.budget.model.tombstone
-import aktual.budget.tags.vm.list.toHex
 import aktual.budget.tags.vm.list.toTagItem
+import aktual.budget.tags.vm.toHex
 import aktual.core.model.UuidGenerator
 import aktual.di.BudgetScope
 import alakazam.kotlin.requireMessage
@@ -206,9 +206,10 @@ class EditTagViewModel(
 
         // another row may already own this name — the tag column is UNIQUE. getTag returns null
         // for tombstoned rows, so a non-null owner that getTag can't see is a deleted tag still
-        // squatting on the name
+        // squatting on the name. Only the rename path needs the extra lookup, so skip it on create
         val owner = tagsDao.getTagIdByName(tag)
-        val tombstonedOwner = owner?.takeIf { it != tagId && tagsDao.getTag(it) == null }
+        val tombstonedOwner =
+          if (tagId != null) owner?.takeIf { it != tagId && tagsDao.getTag(it) == null } else null
 
         if (tagId != null && tombstonedOwner != null) {
           // renaming onto a deleted tag's name: writing the name onto our row would trip the

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -8,8 +8,8 @@ import aktual.budget.model.MessageValue
 import aktual.budget.model.TagId
 import aktual.budget.model.messageValue
 import aktual.budget.model.tombstone
+import aktual.budget.tags.vm.list.toHex
 import aktual.budget.tags.vm.list.toTagItem
-import aktual.budget.tags.vm.toHex
 import aktual.core.model.UuidGenerator
 import aktual.di.BudgetScope
 import alakazam.kotlin.requireMessage

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -7,6 +7,7 @@ import aktual.budget.model.LocalChange
 import aktual.budget.model.MessageValue
 import aktual.budget.model.TagId
 import aktual.budget.model.messageValue
+import aktual.budget.model.tombstone
 import aktual.budget.tags.vm.list.toHex
 import aktual.budget.tags.vm.list.toTagItem
 import aktual.core.model.UuidGenerator
@@ -202,12 +203,30 @@ class EditTagViewModel(
         val tag = mutableTag.value.trim()
         val description = mutableDescription.value.trim()
         val color = mutableColor.value?.toHex()
-        // creating a tag reuses any existing row with the same name — even a tombstoned one — so
-        // the old id is resurrected rather than colliding with the UNIQUE constraint (matches
-        // createTag)
-        val id = tagId ?: tagsDao.getTagIdByName(tag) ?: uuidGenerator(::TagId)
-        tagsDao.insert(id = id, tag = tag, color = color, description = description)
-        syncController.syncChanges(insertChanges(id, tag, color, description))
+
+        // another row may already own this name — the tag column is UNIQUE. getTag returns null
+        // for tombstoned rows, so a non-null owner that getTag can't see is a deleted tag still
+        // squatting on the name
+        val owner = tagsDao.getTagIdByName(tag)
+        val tombstonedOwner = owner?.takeIf { it != tagId && tagsDao.getTag(it) == null }
+
+        if (tagId != null && tombstonedOwner != null) {
+          // renaming onto a deleted tag's name: writing the name onto our row would trip the
+          // UNIQUE constraint, so retire the row we were editing and merge the edits onto the
+          // deleted row, resurrecting it under its original id
+          tagsDao.insert(id = tombstonedOwner, tag = tag, color = color, description = description)
+          syncController.syncChanges(
+            listOf(tombstone(dataset = TAGS, row = tagId.toString())) +
+              insertChanges(tombstonedOwner, tag, color, description)
+          )
+        } else {
+          // creating a tag reuses any existing row with the same name — even a tombstoned one —
+          // so the old id is resurrected rather than colliding with the UNIQUE constraint
+          // (matches createTag)
+          val id = tagId ?: owner ?: uuidGenerator(::TagId)
+          tagsDao.insert(id = id, tag = tag, color = color, description = description)
+          syncController.syncChanges(insertChanges(id, tag, color, description))
+        }
         mutableEvents.tryEmit(EditTagEvent.FinishedSaving)
       } catch (e: CancellationException) {
         throw e

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -209,7 +209,7 @@ class EditTagViewModel(
         // squatting on the name. Only the rename path needs the extra lookup, so skip it on create
         val owner = tagsDao.getTagIdByName(tag)
         val tombstonedOwner =
-          if (tagId != null) owner?.takeIf { it != tagId && tagsDao.getTag(it) == null } else null
+          tagId?.let { id -> owner?.takeIf { it != id && tagsDao.getTag(it) == null } }
 
         if (tagId != null && tombstonedOwner != null) {
           // renaming onto a deleted tag's name: writing the name onto our row would trip the


### PR DESCRIPTION
Renaming a tag to a name still held by a tombstoned (deleted) tag tripped the `UNIQUE(tag)` constraint and surfaced a raw SQL error. The create path already resurrected the tombstoned row; the rename path didn't.

`EditTagViewModel.save()` now merges onto the tombstoned owner's id — resurrecting it — and tombstones the row being edited, so exactly one row ever holds the name. The merge is encoded as sync changes so it converges the same way on every client. Active-name collisions are untouched (still blocked by `canSave`).

Adds a regression test covering rename-onto-tombstoned-name.