### PR TITLE
Consolidate tag hex<->Color conversion into one converter

### DIFF
--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
@@ -1,6 +1,8 @@
 package aktual.budget.tags.ui.edit
 
 import aktual.budget.tags.ui.contrastingTextColor
+import aktual.budget.tags.vm.toColorOrNull
+import aktual.budget.tags.vm.toHex
 import aktual.core.icons.material.MaterialIcons
 import aktual.core.icons.material.Tune
 import aktual.core.l10n.Strings
@@ -61,7 +63,6 @@ import androidx.compose.ui.util.fastForEach
 import com.github.skydoves.colorpicker.compose.BrightnessSlider
 import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
-import kotlin.math.roundToInt
 import kotlinx.collections.immutable.persistentListOf
 
 @Suppress("LongMethod")
@@ -91,7 +92,7 @@ internal fun TagColorPicker(
     val fieldAlreadyMatches = hexState.text.toString().trim().toColorOrNull() == color
     if (hexFocused && fieldAlreadyMatches) return@LaunchedEffect
 
-    val hex = color?.toHexRgb().orEmpty()
+    val hex = color?.toHex().orEmpty()
     if (!hexState.text.contentEquals(hex, ignoreCase = true)) {
       hexState.setTextAndPlaceCursorAtEnd(hex)
     }
@@ -327,29 +328,6 @@ private fun Modifier.rotateVertically(): Modifier =
       )
     }
   }
-
-private val Int.hex2
-  get() = toString(radix = 16).padStart(length = 2, padChar = '0')
-
-// formats a Color as "#RRGGBB" (upper case), matching upstream's stored colour format
-internal fun Color.toHexRgb(): String {
-  val r = (red * 255f).roundToInt().coerceIn(0, 255)
-  val g = (green * 255f).roundToInt().coerceIn(0, 255)
-  val b = (blue * 255f).roundToInt().coerceIn(0, 255)
-  return "#${r.hex2}${g.hex2}${b.hex2}".uppercase()
-}
-
-private const val RGB_HEX_LENGTH = 6
-private const val ARGB_HEX_LENGTH = 8
-
-// parses "#rrggbb" / "#aarrggbb" (with or without the leading '#') into a Color, or null if invalid
-internal fun String.toColorOrNull(): Color? {
-  val hex = trim().removePrefix("#")
-  if (hex.length != RGB_HEX_LENGTH && hex.length != ARGB_HEX_LENGTH) return null
-  val value = hex.toLongOrNull(radix = 16) ?: return null
-  val argb = if (hex.length == RGB_HEX_LENGTH) value or 0xFF000000L else value
-  return Color(argb.toInt())
-}
 
 @Preview
 @Composable

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagColorTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/TagColorTest.kt
@@ -1,0 +1,72 @@
+package aktual.budget.tags.vm
+
+import androidx.compose.ui.graphics.Color
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import org.junit.Test
+
+class TagColorTest {
+  @Test
+  fun `Parse 6-char hex`() {
+    assertThat("#aabbcc".toColorOrNull()).isEqualTo(Color(0xFFAABBCC))
+  }
+
+  @Test
+  fun `Parse without leading hash`() {
+    assertThat("aabbcc".toColorOrNull()).isEqualTo(Color(0xFFAABBCC))
+  }
+
+  @Test
+  fun `Parse is case-insensitive`() {
+    assertThat("#AABBCC".toColorOrNull()).isEqualTo("#aabbcc".toColorOrNull())
+  }
+
+  @Test
+  fun `Parse 3-char shorthand expands each nibble`() {
+    assertThat("#abc".toColorOrNull()).isEqualTo(Color(0xFFAABBCC))
+  }
+
+  @Test
+  fun `Parse 8-char ARGB normalises alpha away`() {
+    // a semi-transparent input is stored opaque, so the swatch matches what gets persisted
+    assertThat("#80FF0000".toColorOrNull()).isEqualTo(Color(0xFFFF0000))
+  }
+
+  @Test
+  fun `Parse trims surrounding whitespace`() {
+    assertThat("  #aabbcc  ".toColorOrNull()).isEqualTo(Color(0xFFAABBCC))
+  }
+
+  @Test
+  fun `Parse rejects invalid lengths`() {
+    assertThat("#ab".toColorOrNull()).isNull()
+    assertThat("#abcde".toColorOrNull()).isNull()
+  }
+
+  @Test
+  fun `Parse rejects non-hex characters`() {
+    assertThat("#gggggg".toColorOrNull()).isNull()
+  }
+
+  @Test
+  fun `Parse rejects empty string`() {
+    assertThat("".toColorOrNull()).isNull()
+  }
+
+  @Test
+  fun `Format is uppercase rrggbb`() {
+    assertThat(Color(0xFFAABBCC).toHex()).isEqualTo("#AABBCC")
+  }
+
+  @Test
+  fun `Format drops alpha`() {
+    assertThat(Color(0x80FF0000).toHex()).isEqualTo("#FF0000")
+  }
+
+  @Test
+  fun `Round-trips through parse and format`() {
+    val hex = "#1976D2"
+    assertThat(hex.toColorOrNull()?.toHex()).isEqualTo(hex)
+  }
+}

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -170,7 +170,7 @@ class EditTagViewModelTest {
       val saved = tagsDao.getTag(TagId(GENERATED_ID))
       assertThat(saved).isNotNull().all {
         prop(GetTag::tag).isEqualTo("groceries")
-        prop(GetTag::color).isEqualTo("#aabbcc")
+        prop(GetTag::color).isEqualTo("#AABBCC")
         prop(GetTag::description).isEqualTo("Weekly food shopping")
       }
 

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/TagColor.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/TagColor.kt
@@ -1,0 +1,37 @@
+package aktual.budget.tags.vm
+
+import androidx.compose.ui.graphics.Color
+import kotlin.math.roundToInt
+
+// Single source of truth for hex<->Color in the tags feature: the loader, the editor's save path
+// and the colour-picker field all go through these. Upstream's ColorPicker emits "#RRGGBB"
+// (uppercase, no alpha), so that's the canonical on-disk form.
+
+private const val RGB_SHORTHAND_LENGTH = 3
+private const val RGB_HEX_LENGTH = 6
+private const val ARGB_HEX_LENGTH = 8
+
+// Parses a CSS hex colour into an opaque Color, or null if it isn't valid hex. Accepts "#rgb"
+// shorthand, "#rrggbb" and "#aarrggbb", with or without the leading '#'. Alpha is normalised away
+// (storage is "#rrggbb"), so the swatch the user sees always matches what gets stored
+@Suppress("MagicNumber")
+fun String.toColorOrNull(): Color? {
+  val hex = trim().removePrefix("#")
+  val rrggbb =
+    when (hex.length) {
+      RGB_SHORTHAND_LENGTH -> hex.map { "$it$it" }.joinToString(separator = "")
+      RGB_HEX_LENGTH -> hex
+      ARGB_HEX_LENGTH -> hex.substring(2)
+      else -> return null
+    }
+  val rgb = rrggbb.toLongOrNull(radix = 16) ?: return null
+  return Color(rgb or 0xFF000000L)
+}
+
+// Inverse of [toColorOrNull] — formats as "#RRGGBB" (uppercase, opaque) for storage and display
+@Suppress("MagicNumber")
+fun Color.toHex(): String {
+  fun Float.hex2() =
+    (this * 255f).roundToInt().coerceIn(0, 255).toString(radix = 16).padStart(2, '0')
+  return "#${red.hex2()}${green.hex2()}${blue.hex2()}".uppercase()
+}

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -8,8 +8,8 @@ import aktual.budget.model.MessageValue
 import aktual.budget.model.TagId
 import aktual.budget.model.messageValue
 import aktual.budget.model.tombstone
-import aktual.budget.tags.vm.list.toHex
 import aktual.budget.tags.vm.list.toTagItem
+import aktual.budget.tags.vm.toHex
 import aktual.core.model.UuidGenerator
 import aktual.di.BudgetScope
 import alakazam.kotlin.requireMessage

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/Mappers.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/Mappers.kt
@@ -3,8 +3,7 @@ package aktual.budget.tags.vm.list
 import aktual.budget.db.GetTag
 import aktual.budget.db.GetTags
 import aktual.budget.model.TagId
-import androidx.compose.ui.graphics.Color
-import kotlin.math.roundToInt
+import aktual.budget.tags.vm.toColorOrNull
 
 internal fun GetTags.toTagItem(): TagItem? = toTagItem(id, tag, color, description, hidden)
 
@@ -25,24 +24,4 @@ private fun toTagItem(
     description = description.orEmpty(),
     hidden = hidden == true,
   )
-}
-
-// Tag colors are stored as CSS hex strings (e.g. "#aabbcc"), matching upstream's ColorPicker output
-@Suppress("MagicNumber")
-internal fun String.toColorOrNull(): Color? {
-  val hex = removePrefix("#")
-  val argb =
-    when (hex.length) {
-      3 -> "FF" + hex.map { "$it$it" }.joinToString(separator = "")
-      6 -> "FF$hex"
-      else -> return null
-    }
-  return argb.toLongOrNull(radix = 16)?.let { Color(it) }
-}
-
-// inverse of [toColorOrNull] — formats as "#rrggbb" for storage, matching upstream
-@Suppress("MagicNumber")
-internal fun Color.toHex(): String {
-  fun Float.toHexByte() = (this * 255f).roundToInt().coerceIn(0, 255).toString(16).padStart(2, '0')
-  return "#${red.toHexByte()}${green.toHexByte()}${blue.toHexByte()}"
 }

--- a/scripts/ktfmt.sh
+++ b/scripts/ktfmt.sh
@@ -115,6 +115,13 @@ else
     }
 fi
 
+# Resolve the java binary: prefer JAVA_HOME, fall back to PATH
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    JAVA_BIN="$JAVA_HOME/bin/java"
+else
+    JAVA_BIN="java"
+fi
+
 # Run ktfmt
 if [ "$USE_SYSTEM_KTFMT" = true ]; then
     echo "Using system ktfmt v$SYSTEM_VERSION (mode: $MODE)"
@@ -124,5 +131,5 @@ if [ "$USE_SYSTEM_KTFMT" = true ]; then
 else
     echo "Using cached ktfmt v$KTFMT_VERSION JAR (mode: $MODE)"
     # shellcheck disable=SC2086
-    run_ktfmt java -jar "$KTFMT_JAR" $KTFMT_ARGS
+    run_ktfmt "$JAVA_BIN" -jar "$KTFMT_JAR" $KTFMT_ARGS
 fi


### PR DESCRIPTION
The tags VM and UI each had their own hex⇄`Color` converter, and they disagreed:

- VM (`Mappers.kt`): accepted `#rgb`/`#rrggbb`, rejected 8-char ARGB, output **lowercase**.
- UI (`TagColorPicker.kt`): accepted `#rrggbb`/`#aarrggbb`, rejected 3-char, output **UPPERCASE**.

So typing `#80FF0000` showed a semi-transparent swatch but `save()` silently dropped alpha to `#ff0000`, `#abc` was wrongly flagged invalid, and storage was lowercase while the field rendered uppercase.

Replaced both with a single canonical converter in `tags/vm` (`TagColor.kt`):
- Parse accepts `#rgb` / `#rrggbb` / `#aarrggbb` and normalises alpha to opaque, so the swatch always matches what gets stored.
- Format emits canonical uppercase `#RRGGBB`, matching upstream's `ColorPicker`.
- Used by `Mappers`, `EditTagViewModel` and `TagColorPicker`.

Also fixed `scripts/ktfmt.sh` to resolve `java` via `JAVA_HOME` when it isn't on the `PATH`.

Covered by the new `TagColorTest`; existing VM tests updated for the canonical uppercase output.