### PR TITLE
Fix tags pull-to-refresh blanking the list

### DIFF
--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.Immutable
 
 internal data object Reload : ListTagsAction
 
+internal data object Refresh : ListTagsAction
+
 internal data object OpenSearch : ListTagsAction
 
 internal data object ClearFilter : ListTagsAction

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -119,6 +119,7 @@ internal fun ListTagsScreen(
     onAction = { action ->
       when (action) {
         Reload -> viewModel.reload()
+        Refresh -> viewModel.reload(showLoading = false)
         OpenSearch -> viewModel.openSearch()
         is EditFilterText -> viewModel.setFilterText(action.text)
         ClearFilter -> viewModel.clearFilter()
@@ -177,7 +178,7 @@ private fun ListTagsScaffold(
       BlurredPullToRefreshBox(
         modifier = Modifier.padding(ListTagsDS.listPadding),
         contentAlignment = Alignment.Center,
-        onRefresh = { onAction(Reload) },
+        onRefresh = { onAction(Refresh) },
         isRefreshing = state is Loading,
         blurState = blurState,
         innerPadding = innerPadding,

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -89,6 +89,7 @@ internal fun ListTagsScreen(
   viewModel: ListTagsViewModel = metroViewModel(),
 ) {
   val state by viewModel.state.collectAsStateWithLifecycle()
+  val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
   val snackbar = remember { SnackbarHostState() }
 
   // refresh on return (e.g. after creating or editing a tag) so the list reflects the changes
@@ -115,11 +116,12 @@ internal fun ListTagsScreen(
   ListTagsScaffold(
     modifier = modifier,
     state = state,
+    isRefreshing = isRefreshing,
     snackbarHostState = snackbar,
     onAction = { action ->
       when (action) {
         Reload -> viewModel.reload()
-        Refresh -> viewModel.reload(showLoading = false)
+        Refresh -> viewModel.refresh()
         OpenSearch -> viewModel.openSearch()
         is EditFilterText -> viewModel.setFilterText(action.text)
         ClearFilter -> viewModel.clearFilter()
@@ -136,6 +138,7 @@ private fun ListTagsScaffold(
   state: ListTagsState,
   onAction: ListTagsActionHandler,
   modifier: Modifier = Modifier,
+  isRefreshing: Boolean = false,
   snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
   val blurState = rememberBlurredTopBarState()
@@ -179,7 +182,7 @@ private fun ListTagsScaffold(
         modifier = Modifier.padding(ListTagsDS.listPadding),
         contentAlignment = Alignment.Center,
         onRefresh = { onAction(Refresh) },
-        isRefreshing = state is Loading,
+        isRefreshing = isRefreshing,
         blurState = blurState,
         innerPadding = innerPadding,
       ) { padding ->

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import logcat.logcat
@@ -57,6 +58,7 @@ class ListTagsViewModel(
 
   private val mutableTags = MutableStateFlow<ImmutableList<TagItem>>(persistentListOf())
   private val mutableIsLoading = MutableStateFlow(true)
+  private val mutableIsRefreshing = MutableStateFlow(false)
   private val mutableFailure = MutableStateFlow<String?>(null)
   private var reloadJob: Job? = null
 
@@ -70,6 +72,8 @@ class ListTagsViewModel(
       onBufferOverflow = DROP_OLDEST,
     )
   val events: SharedFlow<ListTagsEvent> = mutableEvents.asSharedFlow()
+
+  val isRefreshing: StateFlow<Boolean> = mutableIsRefreshing.asStateFlow()
 
   val state: StateFlow<ListTagsState> =
     viewModelScope.launchMolecule(Immediate) {
@@ -104,26 +108,28 @@ class ListTagsViewModel(
     savedState[KEY_IS_SEARCH_ACTIVE] = false
   }
 
-  // showLoading = false does a silent refresh (no loading screen), used when returning to the
-  // list after editing a tag elsewhere
-  fun reload(showLoading: Boolean = true) {
-    if (showLoading) {
-      mutableIsLoading.update { true }
-    }
+  fun reload(showLoading: Boolean = true) = load(loading = showLoading, refreshing = false)
+
+  fun refresh() = load(loading = false, refreshing = true)
+
+  private fun load(loading: Boolean, refreshing: Boolean) {
+    mutableIsLoading.update { loading }
+    mutableIsRefreshing.update { refreshing }
     reloadJob?.cancel()
     reloadJob = viewModelScope.launch {
       try {
         val tags = tagsDao.getTags().mapNotNull { it.toTagItem() }.toImmutableList()
         mutableTags.update { tags }
         mutableFailure.update { null }
-        mutableIsLoading.update { false }
       } catch (e: CancellationException) {
-        // a newer reload() cancelled us — leave the flows alone so it can finish
+        // a newer load() cancelled us — leave the flows alone so it can finish
         throw e
       } catch (e: Exception) {
         logcat.e(e) { "Failed loading tags" }
         mutableFailure.update { e.requireMessage() }
+      } finally {
         mutableIsLoading.update { false }
+        mutableIsRefreshing.update { false }
       }
     }
   }


### PR DESCRIPTION
Pull-to-refresh on the tags list dispatched `Reload` → `reload()` with the default `showLoading = true`, flipping state to `Loading` and replacing the whole list with a full-screen spinner instead of hovering the PTR indicator over existing content.

Add a dedicated `Refresh` action for the PTR gesture that does a silent reload (`showLoading = false`), so the list stays in place. The failure-screen retry keeps `Reload` and its loading screen.