### PR TITLE
Nullable readMetadata + restore deleted tags

### DIFF
--- a/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/ManageStorageViewModel.kt
+++ b/aktual-about/vm/src/commonMain/kotlin/aktual/about/vm/ManageStorageViewModel.kt
@@ -165,7 +165,7 @@ class ManageStorageViewModel(
           val budgetId = BudgetId(entry.name)
           val name =
             try {
-              files.readMetadata(budgetId)[DbMetadata.BudgetName] ?: entry.name
+              files.readMetadata(budgetId)?.get(DbMetadata.BudgetName) ?: entry.name
             } catch (_: Exception) {
               entry.name
             }

--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/BudgetFiles.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/BudgetFiles.kt
@@ -2,7 +2,6 @@ package aktual.budget.model
 
 import aktual.di.Closeable
 import kotlinx.serialization.json.Json
-import okio.FileNotFoundException
 import okio.FileSystem
 import okio.Path
 import okio.buffer
@@ -34,9 +33,9 @@ class BudgetFiles(val fileSystem: FileSystem, val directoryPath: Path) : Closeab
     fileSystem.sink(path).buffer().use { sink -> sink.writeUtf8(json) }
   }
 
-  fun readMetadata(id: BudgetId): DbMetadata {
+  fun readMetadata(id: BudgetId): DbMetadata? {
     val path = metadata(id, mkdirs = false)
-    if (!fileSystem.exists(path)) throw FileNotFoundException("$path doesn't exist")
+    if (!fileSystem.exists(path)) return null
     val json = fileSystem.source(path).buffer().use { source -> source.readUtf8() }
     return Json.decodeFromString(DbMetadata.serializer(), json)
   }
@@ -48,7 +47,7 @@ class BudgetFiles(val fileSystem: FileSystem, val directoryPath: Path) : Closeab
       .filter { it.name != "tmp" && fileSystem.metadataOrNull(it)?.isDirectory == true }
       .map { dir ->
         val id = BudgetId(dir.name)
-        val metadata = runCatching { readMetadata(id) }.getOrNull()
+        val metadata = readMetadata(id)
         LocalBudget(id = id, metadata = metadata)
       }
   }

--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/SyncState.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/SyncState.kt
@@ -42,3 +42,6 @@ data class LocalChange(
 
 fun tombstone(dataset: String, row: String): LocalChange =
   LocalChange(dataset, row, column = "tombstone", value = MessageValue.Number(1))
+
+fun untombstone(dataset: String, row: String): LocalChange =
+  LocalChange(dataset, row, column = "tombstone", value = MessageValue.Number(0))

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -15,11 +15,7 @@ import aktual.core.icons.material.Refresh
 import aktual.core.icons.material.Search
 import aktual.core.icons.material.SearchOff
 import aktual.core.l10n.Plurals
-import aktual.core.l10n.Res
 import aktual.core.l10n.Strings
-import aktual.core.l10n.tags_delete_failed
-import aktual.core.l10n.tags_delete_failed_unknown
-import aktual.core.l10n.tags_deleted
 import aktual.core.nav.EditTagNavigator
 import aktual.core.ui.AktualTextField
 import aktual.core.ui.AktualTheme.colors
@@ -80,7 +76,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.zacsweers.metrox.viewmodel.metroViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import org.jetbrains.compose.resources.getString
 
 @Composable
 internal fun ListTagsScreen(
@@ -102,13 +97,9 @@ internal fun ListTagsScreen(
   LaunchedEffect(viewModel) {
     viewModel.events.collect { event ->
       when (event) {
-        is ListTagsEvent.Deleted ->
-          snackbar.showSnackbar(getString(Res.string.tags_deleted, event.tag))
-        is ListTagsEvent.DeleteFailed ->
-          snackbar.showSnackbar(
-            event.tag?.let { getString(Res.string.tags_delete_failed, it) }
-              ?: getString(Res.string.tags_delete_failed_unknown)
-          )
+        is ListTagsEvent.Deleted -> snackbar.showDeleted(event, onUndo = viewModel::undoDelete)
+        is ListTagsEvent.DeleteFailed -> snackbar.showDeleteFailed(event)
+        is ListTagsEvent.RestoreFailed -> snackbar.showRestoreFailed(event)
       }
     }
   }

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsSnackbars.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsSnackbars.kt
@@ -1,0 +1,41 @@
+package aktual.budget.tags.ui.list
+
+import aktual.budget.tags.vm.list.ListTagsEvent
+import aktual.budget.tags.vm.list.TagItem
+import aktual.core.l10n.Res
+import aktual.core.l10n.tags_delete_failed
+import aktual.core.l10n.tags_delete_failed_unknown
+import aktual.core.l10n.tags_deleted
+import aktual.core.l10n.tags_deleted_undo
+import aktual.core.l10n.tags_restore_failed
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import org.jetbrains.compose.resources.getString
+
+// shows the delete confirmation with an undo action, invoking onUndo if the user taps it
+internal suspend fun SnackbarHostState.showDeleted(
+  event: ListTagsEvent.Deleted,
+  onUndo: (TagItem, Int) -> Unit,
+) {
+  val result =
+    showSnackbar(
+      message = getString(Res.string.tags_deleted, event.item.tag),
+      actionLabel = getString(Res.string.tags_deleted_undo),
+      duration = SnackbarDuration.Long,
+    )
+  if (result == SnackbarResult.ActionPerformed) {
+    onUndo(event.item, event.index)
+  }
+}
+
+internal suspend fun SnackbarHostState.showDeleteFailed(event: ListTagsEvent.DeleteFailed) {
+  showSnackbar(
+    event.tag?.let { getString(Res.string.tags_delete_failed, it) }
+      ?: getString(Res.string.tags_delete_failed_unknown)
+  )
+}
+
+internal suspend fun SnackbarHostState.showRestoreFailed(event: ListTagsEvent.RestoreFailed) {
+  showSnackbar(getString(Res.string.tags_restore_failed, event.tag))
+}

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -4,6 +4,7 @@ import aktual.budget.db.BudgetDatabase
 import aktual.budget.db.dao.TagsDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
+import aktual.budget.model.MessageValue
 import aktual.budget.model.TagId
 import aktual.budget.tags.vm.insertTag
 import aktual.test.TestSyncController
@@ -118,10 +119,11 @@ class ListTagsViewModelTest {
       cancelAndIgnoreRemainingEvents()
     }
 
-    // deleting one tag emits a confirmation event for it
+    // deleting one tag emits a confirmation event carrying the removed item
     viewModel.events.test {
       viewModel.delete(TagId("groceries-id"))
-      assertThat(awaitItem()).isEqualTo(ListTagsEvent.Deleted("groceries"))
+      val event = assertThat(awaitItem()).isInstanceOf(ListTagsEvent.Deleted::class)
+      event.prop(ListTagsEvent.Deleted::item).prop(TagItem::tag).isEqualTo("groceries")
     }
 
     // a tombstone change was queued for sync
@@ -138,6 +140,49 @@ class ListTagsViewModelTest {
         .containsExactly("rent")
       cancelAndIgnoreRemainingEvents()
     }
+  }
+
+  @Test
+  fun `Undo restores a deleted tag at its original position`() = runDatabaseTest {
+    insertTag(id = "groceries-id", tag = "groceries")
+    insertTag(id = "rent-id", tag = "rent")
+
+    val sync = TestSyncController()
+    val viewModel = createViewModel(sync)
+
+    // wait for the initial load with both tags
+    viewModel.state.test {
+      assertThat(awaitItem()).isInstanceOf(Success::class).prop(Success::tags).hasSize(2)
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    // delete the first tag, capturing the event we'd hand back to undo
+    lateinit var deleted: ListTagsEvent.Deleted
+    viewModel.events.test {
+      viewModel.delete(TagId("groceries-id"))
+      val event = awaitItem()
+      assertThat(event).isInstanceOf(ListTagsEvent.Deleted::class)
+      deleted = event as ListTagsEvent.Deleted
+    }
+
+    // undoing puts it back where it was
+    viewModel.undoDelete(deleted.item, deleted.index)
+    viewModel.state.test {
+      assertThat(awaitItem())
+        .isInstanceOf(Success::class)
+        .prop(Success::tags)
+        .extracting(TagItem::tag)
+        .containsExactly("groceries", "rent")
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    // the delete tombstone and its reversal were both queued for sync
+    assertThat(sync.changes)
+      .extracting(LocalChange::row, LocalChange::column, LocalChange::value)
+      .containsExactly(
+        Triple("groceries-id", "tombstone", MessageValue.Number(1)),
+        Triple("groceries-id", "tombstone", MessageValue.Number(0)),
+      )
   }
 
   @Test

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -214,6 +214,43 @@ class ListTagsViewModelTest {
     }
   }
 
+  @Test
+  fun `Undo failure emits a RestoreFailed event and doesn't re-insert the tag`() = runDatabaseTest {
+    insertTag(id = "rent-id", tag = "rent")
+
+    val viewModel = createViewModel(sync = FailingSyncController())
+
+    // wait for the initial load
+    viewModel.state.test {
+      assertThat(awaitItem()).isInstanceOf(Success::class).prop(Success::tags).hasSize(1)
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    // a failing sync while undoing surfaces a RestoreFailed event rather than failing silently
+    val deleted =
+      TagItem(
+        id = TagId("groceries-id"),
+        tag = "groceries",
+        color = null,
+        description = "",
+        hidden = false,
+      )
+    viewModel.events.test {
+      viewModel.undoDelete(deleted, index = 0)
+      assertThat(awaitItem()).isEqualTo(ListTagsEvent.RestoreFailed("groceries"))
+    }
+
+    // and the tag wasn't re-inserted since the restore didn't go through
+    viewModel.state.test {
+      assertThat(awaitItem())
+        .isInstanceOf(Success::class)
+        .prop(Success::tags)
+        .extracting(TagItem::tag)
+        .containsExactly("rent")
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
   private fun BudgetDatabase.createViewModel(sync: BudgetSyncController = TestSyncController()) =
     ListTagsViewModel(SavedStateHandle(), TagsDao(this), sync)
 

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsEvent.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsEvent.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Immutable
 
 @Immutable
 sealed interface ListTagsEvent {
-  // the tombstoned tag's name, so the UI can show a confirmation toast
-  @JvmInline value class Deleted(val tag: String) : ListTagsEvent
+  data class Deleted(val item: TagItem, val index: Int) : ListTagsEvent
 
-  // a delete attempt failed — tag is the name if we knew it, null otherwise
   @JvmInline value class DeleteFailed(val tag: String?) : ListTagsEvent
+
+  @JvmInline value class RestoreFailed(val tag: String) : ListTagsEvent
 }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
@@ -5,6 +5,7 @@ import aktual.budget.db.dao.TagsDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.TagId
 import aktual.budget.model.tombstone
+import aktual.budget.model.untombstone
 import aktual.di.BudgetScope
 import alakazam.kotlin.requireMessage
 import androidx.compose.runtime.Stable
@@ -136,21 +137,46 @@ class ListTagsViewModel(
 
   fun delete(id: TagId) {
     viewModelScope.launch {
-      val name = mutableTags.value.firstOrNull { it.id == id }?.tag
+      val index = mutableTags.value.indexOfFirst { it.id == id }
+      val item = mutableTags.value.getOrNull(index)
       try {
         // syncChanges applies the tombstone to the local db and queues it for sync
         syncController.syncChanges(tombstone(dataset = TAGS, row = id.toString()))
         // optimistically drop the row so it animates out without a loading flash
         mutableTags.update { tags -> tags.filterNot { it.id == id }.toImmutableList() }
-        if (name != null) {
-          mutableEvents.tryEmit(ListTagsEvent.Deleted(name))
+        if (item != null) {
+          mutableEvents.tryEmit(ListTagsEvent.Deleted(item, index))
         }
         logcat.d { "Tombstoned tag $id" }
       } catch (e: CancellationException) {
         throw e
       } catch (e: Exception) {
         logcat.e(e) { "Failed deleting tag $id" }
-        mutableEvents.tryEmit(ListTagsEvent.DeleteFailed(name))
+        mutableEvents.tryEmit(ListTagsEvent.DeleteFailed(item?.tag))
+      }
+    }
+  }
+
+  fun undoDelete(item: TagItem, index: Int) {
+    viewModelScope.launch {
+      try {
+        // reverse the tombstone in the local db and queue the reversal for sync. The row's other
+        // columns were never touched by the delete, so clearing the tombstone fully restores it
+        syncController.syncChanges(untombstone(dataset = TAGS, row = item.id.toString()))
+        // optimistically slot the row back where it was so it animates in
+        mutableTags.update { tags ->
+          if (tags.any { it.id == item.id }) {
+            tags
+          } else {
+            tags.toMutableList().apply { add(index.coerceIn(0, size), item) }.toImmutableList()
+          }
+        }
+        logcat.d { "Restored tag ${item.id}" }
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        logcat.e(e) { "Failed restoring tag ${item.id}" }
+        mutableEvents.tryEmit(ListTagsEvent.RestoreFailed(item.tag))
       }
     }
   }

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -11,8 +11,10 @@
   <string name="tags_create">Create tag</string>
   <string name="tags_delete">Delete</string>
   <string name="tags_deleted">Deleted #%1$s</string>
+  <string name="tags_deleted_undo">Undo</string>
   <string name="tags_delete_failed">Couldn\'t delete #%1$s</string>
   <string name="tags_delete_failed_unknown">Couldn\'t delete tag</string>
+  <string name="tags_restore_failed">Couldn\'t restore #%1$s</string>
   <string name="tags_create_title">New tag</string>
   <string name="tags_edit_title">Edit tag</string>
   <string name="tags_create_tag_label">Tag</string>

--- a/aktual-di/runlevel/impl/src/commonMain/kotlin/aktual/di/RunLevelInitialiserImpl.kt
+++ b/aktual-di/runlevel/impl/src/commonMain/kotlin/aktual/di/RunLevelInitialiserImpl.kt
@@ -39,8 +39,9 @@ class RunLevelInitialiserImpl(
   private suspend fun MutableList<AktualGraph>.addFrom(graph: LoggedInGraph) {
     val budgetId = preferences.lastOpenedBudgetId.get()
     if (budgetId != null) {
-      val driver = driverFactory.create(budgetId)
       files.readMetadata(budgetId)?.let { metadata ->
+        // only open the driver once we know the metadata exists, otherwise it would leak
+        val driver = driverFactory.create(budgetId)
         val budgetGraph = graph.budgetGraphFactory.create(budgetId, metadata, driver)
         add(budgetGraph)
       }

--- a/aktual-di/runlevel/impl/src/commonMain/kotlin/aktual/di/RunLevelInitialiserImpl.kt
+++ b/aktual-di/runlevel/impl/src/commonMain/kotlin/aktual/di/RunLevelInitialiserImpl.kt
@@ -40,9 +40,10 @@ class RunLevelInitialiserImpl(
     val budgetId = preferences.lastOpenedBudgetId.get()
     if (budgetId != null) {
       val driver = driverFactory.create(budgetId)
-      val metadata = files.readMetadata(budgetId)
-      val budgetGraph = graph.budgetGraphFactory.create(budgetId, metadata, driver)
-      add(budgetGraph)
+      files.readMetadata(budgetId)?.let { metadata ->
+        val budgetGraph = graph.budgetGraphFactory.create(budgetId, metadata, driver)
+        add(budgetGraph)
+      }
     }
   }
 }


### PR DESCRIPTION
Two unrelated changes on this branch:

**Make readMetadata nullable** — `readMetadata` can now return null and callers handle the absent case.

**Support restoring deleted tags** — adds an undo action to the tag-deletion snackbar. Since deletes are already optimistic (just sets `tombstone = 1`, leaving the row intact), undo clears the tombstone and slots the row back at its original position.
- New `untombstone()` sync helper mirroring `tombstone()`.
- `Deleted` event carries the item + original index; new `RestoreFailed` event.
- `undoDelete()` in the VM; snackbar gains an Undo action (`SnackbarDuration.Long`).
- Snackbar `when` branches extracted into `ListTagsSnackbars.kt`.
- VM tests updated + a new test covering position-preserving restore.
