### PR TITLE
Navigate to tagged transactions

### DIFF
--- a/.claude/skills/apply-upstream-migration/SKILL.md
+++ b/.claude/skills/apply-upstream-migration/SKILL.md
@@ -31,7 +31,7 @@ For each statement:
 | Statement | Actions needed |
 |-----------|---------------|
 | `ALTER TABLE t ADD COLUMN c` | Update `.sq` file + possible adapter |
-| `CREATE TABLE t` | New `.sq` file + adapter + `BuildDatabase.kt` + possible ID type |
+| `CREATE TABLE t` | New `.sq` file + adapter + `BuildDatabase.kt` + possible ID type. Emit as `CREATE TABLE IF NOT EXISTS` in the migration (never bare `CREATE TABLE`) |
 | `CREATE INDEX` | Add to the relevant `.sq` file (no adapter) |
 
 Also check if new column types need new model classes (sealed interfaces, value class IDs).
@@ -112,7 +112,7 @@ private suspend fun Migrator.migrate1778510362740() =
 
 Rules:
 - **One String per DDL statement** — `driver.execute()` doesn't support semicolon-separated multi-statement strings
-- **`CREATE TABLE IF NOT EXISTS`** — always use; fresh databases already have the table from the schema
+- **`CREATE TABLE IF NOT EXISTS`** — always emit this form, even when upstream wrote a bare `CREATE TABLE`; fresh databases already have the table from the schema
 - **`ALTER TABLE ... ADD COLUMN`** — use as-is; the `version !in previousMigrations` guard handles idempotency for existing databases
 - Never call `BudgetDatabase.Schema.migrate()` — upstream doesn't use `user_version`
 

--- a/aktual-budget/data/db/src/commonMain/kotlin/aktual/budget/db/dao/TransactionDao.kt
+++ b/aktual-budget/data/db/src/commonMain/kotlin/aktual/budget/db/dao/TransactionDao.kt
@@ -1,6 +1,7 @@
 package aktual.budget.db.dao
 
 import aktual.budget.db.BudgetDatabase
+import aktual.budget.db.NotesContainingHash
 import aktual.budget.db.Transactions
 import aktual.budget.db.transactions.GetById
 import aktual.budget.db.withResult
@@ -21,6 +22,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.datetime.LocalDate
 
+data class TransactionNotes(val id: TransactionId, val notes: String?)
+
 @Inject
 class TransactionDao(database: BudgetDatabase, private val contexts: CoroutineContexts) {
   private val queries = database.transactionsQueries
@@ -38,6 +41,19 @@ class TransactionDao(database: BudgetDatabase, private val contexts: CoroutineCo
     offset: Long,
   ): List<TransactionId> = queries.withResult {
     getIdsByAccountPaged(account, limit, offset).awaitAsList()
+  }
+
+  suspend fun getIdsAndNotes(): List<TransactionNotes> = queries.withResult {
+    getIdsAndNotes().awaitAsList().map { TransactionNotes(it.id, it.notes) }
+  }
+
+  suspend fun getIdsAndNotesByAccount(account: AccountId): List<TransactionNotes> =
+    queries.withResult {
+      getIdsAndNotesByAccount(account).awaitAsList().map { TransactionNotes(it.id, it.notes) }
+    }
+
+  suspend fun getNotesContainingHash(): List<String> = queries.withResult {
+    notesContainingHash().awaitAsList().mapNotNull(NotesContainingHash::notes)
   }
 
   fun observeCount(): Flow<Long> =

--- a/aktual-budget/data/db/src/commonMain/sqldelight/aktual/budget/db/CleanupGroups.sq
+++ b/aktual-budget/data/db/src/commonMain/sqldelight/aktual/budget/db/CleanupGroups.sq
@@ -1,7 +1,7 @@
 import aktual.budget.model.CleanupGroupId;
 import kotlin.Boolean;
 
-CREATE TABLE cleanup_groups(
+CREATE TABLE IF NOT EXISTS cleanup_groups(
   id TEXT AS CleanupGroupId PRIMARY KEY,
   name TEXT NOT NULL,
   tombstone INTEGER AS Boolean DEFAULT 0

--- a/aktual-budget/data/db/src/commonMain/sqldelight/aktual/budget/db/Transactions.sq
+++ b/aktual-budget/data/db/src/commonMain/sqldelight/aktual/budget/db/Transactions.sq
@@ -167,6 +167,17 @@ WHERE account = :account
 ORDER BY date DESC
 LIMIT :limit OFFSET :offset;
 
+-- id + notes for every live transaction, for in-memory #tag filtering (no SQL regex available)
+getIdsAndNotes:
+SELECT id, notes FROM v_transactions ORDER BY date DESC;
+
+getIdsAndNotesByAccount:
+SELECT id, notes FROM v_transactions WHERE account = :account ORDER BY date DESC;
+
+-- notes of every live transaction containing a '#', for aggregating per-tag transaction counts
+notesContainingHash:
+SELECT notes FROM v_transactions WHERE notes LIKE '%#%';
+
 getIdsCount:
 SELECT COUNT(*) FROM v_transactions;
 

--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TagMatching.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TagMatching.kt
@@ -1,0 +1,14 @@
+package aktual.budget.model
+
+// A tag (#name) is "linked" to a transaction when its token appears in the transaction notes,
+// bounded by start/whitespace on the left and whitespace, another '#', or end-of-string on the
+// right. Matching is case-insensitive. Mirrors the hasTags filter in upstream Actual
+// (packages/loot-core/src/server/rules/condition.ts) and the tag extraction in tags/app.ts.
+private val TAG_TOKEN = Regex("""(?<!#)#([^#\s]+)""")
+
+// The distinct tag names (lowercased, without the leading '#') referenced in [notes].
+fun tagsInNotes(notes: String): Set<String> =
+  TAG_TOKEN.findAll(notes).mapTo(mutableSetOf()) { it.groupValues[1].lowercase() }
+
+// Whether [notes] references the tag named [tag] (case-insensitive).
+fun notesContainTag(notes: String, tag: String): Boolean = tag.lowercase() in tagsInNotes(notes)

--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TransactionsSpec.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TransactionsSpec.kt
@@ -2,11 +2,22 @@ package aktual.budget.model
 
 import androidx.compose.runtime.Immutable
 
-@Immutable data class TransactionsSpec(val accountSpec: AccountSpec)
+@Immutable
+data class TransactionsSpec(
+  val accountSpec: AccountSpec = AccountSpec.AllAccounts,
+  val tagSpec: TagSpec = TagSpec.AllTags,
+)
 
 @Immutable
 sealed interface AccountSpec {
   data object AllAccounts : AccountSpec
 
   data class SpecificAccount(val id: AccountId) : AccountSpec
+}
+
+@Immutable
+sealed interface TagSpec {
+  data object AllTags : TagSpec
+
+  data class SpecificTag(val id: TagId) : TagSpec
 }

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/TagsNavEntryContributor.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/TagsNavEntryContributor.kt
@@ -10,6 +10,7 @@ import aktual.core.nav.EditTagNavRoute
 import aktual.core.nav.EditTagNavigator
 import aktual.core.nav.ListTagsNavRoute
 import aktual.core.nav.NavStack
+import aktual.core.nav.TransactionsNavigator
 import aktual.core.nav.budgetEntry
 import aktual.di.BudgetScope
 import androidx.navigation3.runtime.EntryProviderScope
@@ -18,7 +19,12 @@ import dev.zacsweers.metro.ContributesIntoSet
 @ContributesIntoSet(BudgetScope::class)
 class TagsNavEntryContributor : BudgetNavEntryContributor {
   override fun EntryProviderScope<BudgetNavKey>.contribute(stack: NavStack<BudgetNavKey>) {
-    budgetEntry<ListTagsNavRoute> { ListTagsScreen(toEdit = EditTagNavigator(stack)) }
+    budgetEntry<ListTagsNavRoute> {
+      ListTagsScreen(
+        toEdit = EditTagNavigator(stack),
+        toTransactions = TransactionsNavigator(stack),
+      )
+    }
 
     budgetEntry<CreateTagNavRoute> { EditTagScreen(id = null, back = BackNavigator(stack)) }
 

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagDS.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/EditTagDS.kt
@@ -8,7 +8,7 @@ internal object EditTagDS {
   val labelSpacing = 4.dp
 
   val colorPickerSectionSpacing = 12.dp
-  val colorWheelHeight = 220.dp
+  val colorWheelSize = 220.dp
   val brightnessSliderHeight = 28.dp
   val colorPresetSpacing = 4.dp
   val colorPresetSize = 30.dp

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
@@ -191,7 +191,7 @@ internal fun TagColorPicker(
         verticalAlignment = Alignment.CenterVertically,
       ) {
         HsvColorPicker(
-          modifier = Modifier.weight(1f).height(EditTagDS.colorWheelHeight),
+          modifier = Modifier.weight(1f).size(EditTagDS.colorWheelSize),
           controller = controller,
           initialColor = color ?: TAG_COLOR_PRESETS.first(),
           onColorChanged = { envelope -> if (envelope.fromUser) onColorChange(envelope.color) },
@@ -200,7 +200,7 @@ internal fun TagColorPicker(
         BrightnessSlider(
           modifier =
             Modifier.rotateVertically()
-              .width(EditTagDS.colorWheelHeight)
+              .width(EditTagDS.colorWheelSize)
               .height(EditTagDS.brightnessSliderHeight)
               .clip(CardShape)
               .border(1.dp, colors.pageText, CardShape),

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
@@ -9,7 +9,6 @@ import aktual.core.icons.material.Tune
 import aktual.core.l10n.Strings
 import aktual.core.ui.AktualTextField
 import aktual.core.ui.AktualTheme.colors
-import aktual.core.ui.BareIconButton
 import aktual.core.ui.ButtonShape
 import aktual.core.ui.CardShape
 import aktual.core.ui.ColoredBooleanParameters

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
@@ -4,6 +4,7 @@ import aktual.budget.tags.ui.contrastingTextColor
 import aktual.budget.tags.vm.toColorOrNull
 import aktual.budget.tags.vm.toHex
 import aktual.core.icons.material.MaterialIcons
+import aktual.core.icons.material.Shuffle
 import aktual.core.icons.material.Tune
 import aktual.core.l10n.Strings
 import aktual.core.ui.AktualTextField
@@ -14,6 +15,7 @@ import aktual.core.ui.CardShape
 import aktual.core.ui.ColoredBooleanParameters
 import aktual.core.ui.ColoredParams
 import aktual.core.ui.IconButtonColorProvider
+import aktual.core.ui.NormalIconButton
 import aktual.core.ui.PreviewWithColoredParams
 import aktual.core.ui.textField
 import androidx.compose.animation.AnimatedVisibility
@@ -63,6 +65,7 @@ import androidx.compose.ui.util.fastForEach
 import com.github.skydoves.colorpicker.compose.BrightnessSlider
 import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
+import kotlin.random.Random
 import kotlinx.collections.immutable.persistentListOf
 
 @Suppress("LongMethod")
@@ -150,12 +153,21 @@ internal fun TagColorPicker(
         isError = hexError,
       )
 
-      BareIconButton(
+      NormalIconButton(
+        imageVector = MaterialIcons.Shuffle,
+        contentDescription = Strings.tagsCreateColorRandom,
+        // grid: pick from the presets; advanced: any colour is fair game
+        onClick = {
+          onColorChange(if (advancedVisible) randomColor() else TAG_COLOR_PRESETS.random())
+        },
+      )
+
+      NormalIconButton(
         imageVector = MaterialIcons.Tune,
         contentDescription = Strings.tagsCreateColorAdvanced,
         onClick = { advancedVisible = !advancedVisible },
         colors =
-          if (advancedVisible) IconButtonColorProvider.Primary else IconButtonColorProvider.Bare,
+          if (advancedVisible) IconButtonColorProvider.Primary else IconButtonColorProvider.Normal,
       )
     }
 
@@ -321,6 +333,9 @@ internal val TAG_COLOR_PRESETS =
     Color(0xFFE4D3C3),
     Color(0xFFDADADA),
   )
+
+private fun randomColor(): Color =
+  Color(red = Random.nextInt(256), green = Random.nextInt(256), blue = Random.nextInt(256))
 
 // Rotates a composable 90° and swaps its measured bounds so it occupies the rotated footprint.
 // Modifiers chained after this describe the composable in its original (horizontal) orientation.

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/edit/TagColorPicker.kt
@@ -333,8 +333,10 @@ internal val TAG_COLOR_PRESETS =
     Color(0xFFDADADA),
   )
 
+private const val HEX = 256
+
 private fun randomColor(): Color =
-  Color(red = Random.nextInt(256), green = Random.nextInt(256), blue = Random.nextInt(256))
+  Color(red = Random.nextInt(HEX), green = Random.nextInt(HEX), blue = Random.nextInt(HEX))
 
 // Rotates a composable 90° and swaps its measured bounds so it occupies the rotated footprint.
 // Modifiers chained after this describe the composable in its original (horizontal) orientation.

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
@@ -19,6 +19,8 @@ internal data object CreateTag : ListTagsAction
 
 @JvmInline internal value class EditTag(val id: TagId) : ListTagsAction
 
+@JvmInline internal value class ViewTransactions(val id: TagId) : ListTagsAction
+
 @JvmInline internal value class DeleteTag(val id: TagId) : ListTagsAction
 
 @Immutable

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsDS.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsDS.kt
@@ -13,5 +13,6 @@ internal object ListTagsDS {
   val itemContentSpacing = 6.dp
   val chipShape = RoundedCornerShape(size = 16.dp)
   val chipPadding = PaddingValues(horizontal = 7.dp, vertical = 3.dp)
+  val numTransactionsPadding = PaddingValues(all = 4.dp)
   const val HIDDEN_ALPHA = 0.5f
 }

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -17,6 +17,7 @@ import aktual.core.icons.material.SearchOff
 import aktual.core.l10n.Plurals
 import aktual.core.l10n.Strings
 import aktual.core.nav.EditTagNavigator
+import aktual.core.nav.TransactionsNavigator
 import aktual.core.ui.AktualTextField
 import aktual.core.ui.AktualTheme.colors
 import aktual.core.ui.AktualTheme.typography
@@ -80,6 +81,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 internal fun ListTagsScreen(
   toEdit: EditTagNavigator,
+  toTransactions: TransactionsNavigator,
   modifier: Modifier = Modifier,
   viewModel: ListTagsViewModel = metroViewModel(),
 ) {
@@ -119,6 +121,7 @@ internal fun ListTagsScreen(
         CreateTag -> toEdit()
         is EditTag -> toEdit(action.id)
         is DeleteTag -> viewModel.delete(action.id)
+        is ViewTransactions -> toTransactions(action.id)
       }
     },
   )

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
@@ -167,8 +167,7 @@ private fun TagItemRow(
       if (tag.numTransactions > 0) {
         Box(
           modifier =
-            Modifier
-              .background(colors.pillBackgroundSelected, CardShape)
+            Modifier.background(colors.pillBackgroundSelected, CardShape)
               .clickable { onAction(ViewTransactions(tag.id)) }
               .padding(ListTagsDS.numTransactionsPadding),
           contentAlignment = Alignment.Center,

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagItem.kt
@@ -4,9 +4,11 @@ import aktual.budget.tags.ui.contrastingTextColor
 import aktual.budget.tags.vm.list.TagItem
 import aktual.core.icons.material.Delete
 import aktual.core.icons.material.MaterialIcons
+import aktual.core.l10n.Plurals
 import aktual.core.l10n.Strings
 import aktual.core.ui.AktualTheme.colors
 import aktual.core.ui.AktualTheme.typography
+import aktual.core.ui.CardShape
 import aktual.core.ui.ColoredParameterProvider
 import aktual.core.ui.ColoredParams
 import aktual.core.ui.PreviewWithColoredParams
@@ -161,6 +163,23 @@ private fun TagItemRow(
         maxLines = 5,
         overflow = TextOverflow.Ellipsis,
       )
+
+      if (tag.numTransactions > 0) {
+        Box(
+          modifier =
+            Modifier
+              .background(colors.pillBackgroundSelected, CardShape)
+              .clickable { onAction(ViewTransactions(tag.id)) }
+              .padding(ListTagsDS.numTransactionsPadding),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(
+            text = Plurals.tagsNumTransactions(tag.numTransactions, tag.numTransactions),
+            style = typography.bodySmall,
+            color = colors.pillText,
+          )
+        }
+      }
     }
   }
 }

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagsPreview.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagsPreview.kt
@@ -14,6 +14,7 @@ internal object TagsPreview {
       color = Color(0xFF4CAF50),
       description = "Weekly food shopping",
       hidden = false,
+      numTransactions = 0,
     )
 
   val rent =
@@ -23,6 +24,7 @@ internal object TagsPreview {
       color = Color(0xFFE91E63),
       description = "",
       hidden = false,
+      numTransactions = 1,
     )
 
   val archived =
@@ -34,6 +36,7 @@ internal object TagsPreview {
         "A deliberately long description to check how the item wraps and truncates when the text " +
           "runs well beyond the available width of the row",
       hidden = true,
+      numTransactions = 10,
     )
 
   // no explicit color — exercises the theme note-tag fallback
@@ -44,6 +47,7 @@ internal object TagsPreview {
       color = null,
       description = "",
       hidden = false,
+      numTransactions = 0,
     )
 
   val all: ImmutableList<TagItem> = persistentListOf(groceries, rent, archived, uncolored)

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -2,6 +2,7 @@ package aktual.budget.tags.vm.list
 
 import aktual.budget.db.BudgetDatabase
 import aktual.budget.db.dao.TagsDao
+import aktual.budget.db.dao.TransactionDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
 import aktual.budget.model.MessageValue
@@ -9,6 +10,8 @@ import aktual.budget.model.TagId
 import aktual.budget.tags.vm.insertTag
 import aktual.test.TestSyncController
 import aktual.test.runDatabaseTest
+import alakazam.test.TestCoroutineContexts
+import alakazam.test.standardDispatcher
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
@@ -20,6 +23,7 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
+import kotlinx.coroutines.test.TestScope
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -27,7 +31,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ListTagsViewModelTest {
   @Test
-  fun `Loads and maps tags from the database`() = runDatabaseTest {
+  fun `Loads and maps tags from the database`() = runDatabaseTest { scope ->
     // given a couple of tags - one with an explicit hex color, one with neither color nor
     // description
     insertTag(
@@ -39,7 +43,7 @@ class ListTagsViewModelTest {
     insertTag(id = "rent-id", tag = "rent")
 
     // when the VM loads
-    val viewModel = createViewModel()
+    val viewModel = createViewModel(scope)
 
     // then the state settles on the mapped tags
     viewModel.state.test {
@@ -69,9 +73,9 @@ class ListTagsViewModelTest {
   }
 
   @Test
-  fun `Empty database yields the empty state`() = runDatabaseTest {
+  fun `Empty database yields the empty state`() = runDatabaseTest { scope ->
     // when the VM loads with no tags in the database
-    val viewModel = createViewModel()
+    val viewModel = createViewModel(scope)
 
     // then we get the empty state rather than a failure
     viewModel.state.test {
@@ -81,11 +85,11 @@ class ListTagsViewModelTest {
   }
 
   @Test
-  fun `Filter matches against tag name and description`() = runDatabaseTest {
+  fun `Filter matches against tag name and description`() = runDatabaseTest { scope ->
     insertTag(id = "groceries-id", tag = "groceries", description = "Weekly food shopping")
     insertTag(id = "rent-id", tag = "rent", description = "Monthly housing")
 
-    val viewModel = createViewModel()
+    val viewModel = createViewModel(scope)
 
     viewModel.state.test {
       // wait for the initial unfiltered load
@@ -108,12 +112,12 @@ class ListTagsViewModelTest {
   }
 
   @Test
-  fun `Delete tombstones the tag, removes it, and emits an event`() = runDatabaseTest {
+  fun `Delete tombstones the tag, removes it, and emits an event`() = runDatabaseTest { scope ->
     insertTag(id = "groceries-id", tag = "groceries")
     insertTag(id = "rent-id", tag = "rent")
 
     val sync = TestSyncController()
-    val viewModel = createViewModel(sync)
+    val viewModel = createViewModel(scope, sync)
 
     // wait for the initial load with both tags
     viewModel.state.test {
@@ -145,12 +149,12 @@ class ListTagsViewModelTest {
   }
 
   @Test
-  fun `Undo restores a deleted tag at its original position`() = runDatabaseTest {
+  fun `Undo restores a deleted tag at its original position`() = runDatabaseTest { scope ->
     insertTag(id = "groceries-id", tag = "groceries")
     insertTag(id = "rent-id", tag = "rent")
 
     val sync = TestSyncController()
-    val viewModel = createViewModel(sync)
+    val viewModel = createViewModel(scope, sync)
 
     // wait for the initial load with both tags
     viewModel.state.test {
@@ -188,10 +192,10 @@ class ListTagsViewModelTest {
   }
 
   @Test
-  fun `Delete failure emits a DeleteFailed event and keeps the tag`() = runDatabaseTest {
+  fun `Delete failure emits a DeleteFailed event and keeps the tag`() = runDatabaseTest { scope ->
     insertTag(id = "groceries-id", tag = "groceries")
 
-    val viewModel = createViewModel(sync = FailingSyncController())
+    val viewModel = createViewModel(scope, sync = FailingSyncController())
 
     // wait for the initial load
     viewModel.state.test {
@@ -217,45 +221,55 @@ class ListTagsViewModelTest {
   }
 
   @Test
-  fun `Undo failure emits a RestoreFailed event and doesn't re-insert the tag`() = runDatabaseTest {
-    insertTag(id = "rent-id", tag = "rent")
+  fun `Undo failure emits a RestoreFailed event and doesn't re-insert the tag`() =
+    runDatabaseTest { scope ->
+      insertTag(id = "rent-id", tag = "rent")
 
-    val viewModel = createViewModel(sync = FailingSyncController())
+      val viewModel = createViewModel(scope, sync = FailingSyncController())
 
-    // wait for the initial load
-    viewModel.state.test {
-      assertThat(awaitItem()).isInstanceOf(Success::class).prop(Success::tags).hasSize(1)
-      cancelAndIgnoreRemainingEvents()
+      // wait for the initial load
+      viewModel.state.test {
+        assertThat(awaitItem()).isInstanceOf(Success::class).prop(Success::tags).hasSize(1)
+        cancelAndIgnoreRemainingEvents()
+      }
+
+      // a failing sync while undoing surfaces a RestoreFailed event rather than failing silently
+      val deleted =
+        TagItem(
+          id = TagId("groceries-id"),
+          tag = "groceries",
+          color = null,
+          description = "",
+          hidden = false,
+          numTransactions = 0,
+        )
+      viewModel.events.test {
+        viewModel.undoDelete(deleted, index = 0)
+        assertThat(awaitItem()).isEqualTo(ListTagsEvent.RestoreFailed("groceries"))
+      }
+
+      // and the tag wasn't re-inserted since the restore didn't go through
+      viewModel.state.test {
+        assertThat(awaitItem())
+          .isInstanceOf(Success::class)
+          .prop(Success::tags)
+          .extracting(TagItem::tag)
+          .containsExactly("rent")
+        cancelAndIgnoreRemainingEvents()
+      }
     }
 
-    // a failing sync while undoing surfaces a RestoreFailed event rather than failing silently
-    val deleted =
-      TagItem(
-        id = TagId("groceries-id"),
-        tag = "groceries",
-        color = null,
-        description = "",
-        hidden = false,
-        numTransactions = 0,
-      )
-    viewModel.events.test {
-      viewModel.undoDelete(deleted, index = 0)
-      assertThat(awaitItem()).isEqualTo(ListTagsEvent.RestoreFailed("groceries"))
-    }
-
-    // and the tag wasn't re-inserted since the restore didn't go through
-    viewModel.state.test {
-      assertThat(awaitItem())
-        .isInstanceOf(Success::class)
-        .prop(Success::tags)
-        .extracting(TagItem::tag)
-        .containsExactly("rent")
-      cancelAndIgnoreRemainingEvents()
-    }
-  }
-
-  private fun BudgetDatabase.createViewModel(sync: BudgetSyncController = TestSyncController()) =
-    ListTagsViewModel(SavedStateHandle(), TagsDao(this), sync)
+  private fun BudgetDatabase.createViewModel(
+    scope: TestScope,
+    sync: BudgetSyncController = TestSyncController(),
+  ) =
+    ListTagsViewModel(
+      savedState = SavedStateHandle(),
+      tagsDao = TagsDao(this),
+      transactionDao =
+        TransactionDao(database = this, contexts = TestCoroutineContexts(scope.standardDispatcher)),
+      syncController = sync,
+    )
 
   private class FailingSyncController : BudgetSyncController {
     override suspend fun syncChanges(changes: List<LocalChange>): Unit = error("sync failed")

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -53,6 +53,7 @@ class ListTagsViewModelTest {
             color = Color(0xFFAABBCC),
             description = "Weekly food shopping",
             hidden = false,
+            numTransactions = 0,
           ),
           TagItem(
             id = TagId("rent-id"),
@@ -60,6 +61,7 @@ class ListTagsViewModelTest {
             color = null,
             description = "",
             hidden = false,
+            numTransactions = 0,
           ),
         )
       cancelAndIgnoreRemainingEvents()
@@ -234,6 +236,7 @@ class ListTagsViewModelTest {
         color = null,
         description = "",
         hidden = false,
+        numTransactions = 0,
       )
     viewModel.events.test {
       viewModel.undoDelete(deleted, index = 0)

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
@@ -2,8 +2,10 @@ package aktual.budget.tags.vm.list
 
 import aktual.budget.db.dao.DatabaseTables.TAGS
 import aktual.budget.db.dao.TagsDao
+import aktual.budget.db.dao.TransactionDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.TagId
+import aktual.budget.model.tagsInNotes
 import aktual.budget.model.tombstone
 import aktual.budget.model.untombstone
 import aktual.di.BudgetScope
@@ -45,6 +47,7 @@ import logcat.logcat
 class ListTagsViewModel(
   @Assisted private val savedState: SavedStateHandle,
   private val tagsDao: TagsDao,
+  private val transactionDao: TransactionDao,
   private val syncController: BudgetSyncController,
 ) : ViewModel() {
   @AssistedFactory
@@ -119,7 +122,12 @@ class ListTagsViewModel(
     reloadJob?.cancel()
     reloadJob = viewModelScope.launch {
       try {
-        val tags = tagsDao.getTags().mapNotNull { it.toTagItem() }.toImmutableList()
+        val counts = transactionCountsByTag()
+        val tags =
+          tagsDao
+            .getTags()
+            .mapNotNull { row -> row.toTagItem(counts[row.tag?.lowercase()] ?: 0) }
+            .toImmutableList()
         mutableTags.update { tags }
         mutableFailure.update { null }
       } catch (e: CancellationException) {
@@ -133,6 +141,18 @@ class ListTagsViewModel(
         mutableIsRefreshing.update { false }
       }
     }
+  }
+
+  // Counts, per lowercased tag name, how many transactions reference that tag in their notes.
+  // A single transaction counts once even if it mentions the tag multiple times.
+  private suspend fun transactionCountsByTag(): Map<String, Int> {
+    val counts = HashMap<String, Int>()
+    for (notes in transactionDao.getNotesContainingHash()) {
+      for (name in tagsInNotes(notes)) {
+        counts[name] = (counts[name] ?: 0) + 1
+      }
+    }
+    return counts
   }
 
   fun delete(id: TagId) {

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/Mappers.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/Mappers.kt
@@ -23,5 +23,6 @@ private fun toTagItem(
     color = color?.toColorOrNull(),
     description = description.orEmpty(),
     hidden = hidden == true,
+    numTransactions = 0 // TOOD: actually implement
   )
 }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/Mappers.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/Mappers.kt
@@ -5,9 +5,11 @@ import aktual.budget.db.GetTags
 import aktual.budget.model.TagId
 import aktual.budget.tags.vm.toColorOrNull
 
-internal fun GetTags.toTagItem(): TagItem? = toTagItem(id, tag, color, description, hidden)
+internal fun GetTags.toTagItem(numTransactions: Int = 0): TagItem? =
+  toTagItem(id, tag, color, description, hidden, numTransactions)
 
-internal fun GetTag.toTagItem(): TagItem? = toTagItem(id, tag, color, description, hidden)
+internal fun GetTag.toTagItem(numTransactions: Int = 0): TagItem? =
+  toTagItem(id, tag, color, description, hidden, numTransactions)
 
 private fun toTagItem(
   id: TagId,
@@ -15,6 +17,7 @@ private fun toTagItem(
   color: String?,
   description: String?,
   hidden: Boolean?,
+  numTransactions: Int,
 ): TagItem? {
   val name = tag ?: return null
   return TagItem(
@@ -23,6 +26,6 @@ private fun toTagItem(
     color = color?.toColorOrNull(),
     description = description.orEmpty(),
     hidden = hidden == true,
-    numTransactions = 0 // TOOD: actually implement
+    numTransactions = numTransactions,
   )
 }

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/TagItem.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/TagItem.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.graphics.Color
 data class TagItem(
   val id: TagId,
   val tag: String,
-  // null when the tag has no explicit color — the UI falls back to the theme's note-tag colors
   val color: Color?,
   val description: String,
   val hidden: Boolean,
+  val numTransactions: Int,
 )

--- a/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsNavEntryContributor.kt
+++ b/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsNavEntryContributor.kt
@@ -1,10 +1,13 @@
 package aktual.budget.transactions.ui
 
+import aktual.budget.model.TagSpec
+import aktual.budget.model.TransactionsSpec
 import aktual.core.nav.BackNavigator
 import aktual.core.nav.BudgetNavEntryContributor
 import aktual.core.nav.BudgetNavKey
 import aktual.core.nav.NavStack
 import aktual.core.nav.TransactionsNavRoute
+import aktual.core.nav.TransactionsWithTagNavRoute
 import aktual.core.nav.budgetEntry
 import aktual.di.BudgetScope
 import androidx.navigation3.runtime.EntryProviderScope
@@ -13,6 +16,15 @@ import dev.zacsweers.metro.ContributesIntoSet
 @ContributesIntoSet(BudgetScope::class)
 class TransactionsNavEntryContributor : BudgetNavEntryContributor {
   override fun EntryProviderScope<BudgetNavKey>.contribute(stack: NavStack<BudgetNavKey>) {
-    budgetEntry<TransactionsNavRoute> { TransactionsScreen(BackNavigator(stack)) }
+    budgetEntry<TransactionsNavRoute> {
+      TransactionsScreen(back = BackNavigator(stack), spec = TransactionsSpec())
+    }
+
+    budgetEntry<TransactionsWithTagNavRoute> { route ->
+      TransactionsScreen(
+        back = BackNavigator(stack),
+        spec = TransactionsSpec(tagSpec = TagSpec.SpecificTag(route.id)),
+      )
+    }
   }
 }

--- a/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsScreen.kt
+++ b/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsScreen.kt
@@ -1,6 +1,5 @@
 package aktual.budget.transactions.ui
 
-import aktual.budget.model.AccountSpec
 import aktual.budget.model.TransactionsFormat
 import aktual.budget.model.TransactionsSpec
 import aktual.budget.transactions.vm.LoadedAccount
@@ -10,6 +9,7 @@ import aktual.budget.transactions.vm.TransactionsViewModel
 import aktual.core.nav.BackNavigator
 import aktual.core.theme.Colors
 import aktual.core.ui.ColoredParameters
+import aktual.core.ui.DesktopPreview
 import aktual.core.ui.LandscapePreview
 import aktual.core.ui.PageBackground
 import aktual.core.ui.PortraitPreview
@@ -31,7 +31,7 @@ import dev.zacsweers.metrox.viewmodel.assistedMetroViewModel
 @Composable
 fun TransactionsScreen(
   back: BackNavigator,
-  spec: TransactionsSpec = TransactionsSpec(AccountSpec.AllAccounts),
+  spec: TransactionsSpec,
   viewModel: TransactionsViewModel = metroViewModel(spec),
 ) {
   val loadedAccount by viewModel.loadedAccount.collectAsStateWithLifecycle()
@@ -100,6 +100,7 @@ internal fun TransactionsScaffold(
 @PortraitPreview
 @LandscapePreview
 @TabletPreview
+@DesktopPreview
 private fun PreviewTransactionsScaffold(
   @PreviewParameter(ColoredParameters::class) colors: Colors
 ) =

--- a/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsTitleBar.kt
+++ b/aktual-budget/transactions/ui/src/commonMain/kotlin/aktual/budget/transactions/ui/TransactionsTitleBar.kt
@@ -40,6 +40,7 @@ internal fun TransactionsTitleBar(
       LoadedAccount.Loading -> Strings.transactionsTitleLoading
       is LoadedAccount.SpecificAccount ->
         loadedAccount.account.name ?: Strings.transactionsTitleNone
+      is LoadedAccount.SpecificTag -> "#${loadedAccount.tag}"
     }
 
   TopAppBar(
@@ -82,4 +83,5 @@ private class TransactionsTitleBarProvider :
     LoadedAccount.AllAccounts,
     LoadedAccount.Loading,
     LoadedAccount.SpecificAccount(PREVIEW_ACCOUNT),
+    LoadedAccount.SpecificTag("groceries"),
   )

--- a/aktual-budget/transactions/vm/src/androidHostTest/kotlin/aktual/budget/transactions/vm/TestDatabaseBindings.kt
+++ b/aktual-budget/transactions/vm/src/androidHostTest/kotlin/aktual/budget/transactions/vm/TestDatabaseBindings.kt
@@ -3,6 +3,7 @@ package aktual.budget.transactions.vm
 import aktual.budget.db.dao.AccountDao
 import aktual.budget.db.dao.CategoryDao
 import aktual.budget.db.dao.PayeeDao
+import aktual.budget.db.dao.TagsDao
 import aktual.budget.db.dao.TransactionDao
 import aktual.di.Accessor
 import aktual.di.AccessorKey
@@ -31,4 +32,6 @@ internal object TestDatabaseBindings {
   @IntoMap
   @AccessorKey(CategoryDao::class)
   fun categories(dao: CategoryDao): Accessor = { dao }
+
+  @Provides @IntoMap @AccessorKey(TagsDao::class) fun tags(dao: TagsDao): Accessor = { dao }
 }

--- a/aktual-budget/transactions/vm/src/androidHostTest/kotlin/aktual/budget/transactions/vm/TransactionsViewModelTest.kt
+++ b/aktual-budget/transactions/vm/src/androidHostTest/kotlin/aktual/budget/transactions/vm/TransactionsViewModelTest.kt
@@ -3,6 +3,7 @@ package aktual.budget.transactions.vm
 import aktual.budget.db.dao.AccountDao
 import aktual.budget.db.dao.CategoryDao
 import aktual.budget.db.dao.PayeeDao
+import aktual.budget.db.dao.TagsDao
 import aktual.budget.db.dao.TransactionDao
 import aktual.budget.model.AccountId
 import aktual.budget.model.AccountSpec
@@ -10,6 +11,8 @@ import aktual.budget.model.AccountSpec.AllAccounts
 import aktual.budget.model.AccountSpec.SpecificAccount
 import aktual.budget.model.CategoryId
 import aktual.budget.model.PayeeId
+import aktual.budget.model.TagId
+import aktual.budget.model.TagSpec
 import aktual.budget.model.TransactionsSpec
 import aktual.core.model.ServerUrl
 import aktual.di.AppGraph
@@ -52,6 +55,7 @@ class TransactionsViewModelTest {
   private lateinit var transactions: TransactionDao
   private lateinit var payees: PayeeDao
   private lateinit var categories: CategoryDao
+  private lateinit var tags: TagsDao
 
   // fake
   private lateinit var appGraph: TestAppGraph
@@ -86,6 +90,7 @@ class TransactionsViewModelTest {
       transactions = budgetGraph[TransactionDao::class]
       payees = budgetGraph[PayeeDao::class]
       categories = budgetGraph[CategoryDao::class]
+      tags = budgetGraph[TagsDao::class]
     }
 
     // add some utility entities
@@ -113,7 +118,12 @@ class TransactionsViewModelTest {
   fun `Empty transaction list from all accounts`() = runTest {
     // given
     buildViewModel(AllAccounts)
-    val source = TransactionsPagingSource(transactions, spec = AllAccounts)
+    val source =
+      TransactionsPagingSource(
+        transactionDao = transactions,
+        tagsDao = tags,
+        spec = TransactionsSpec(AllAccounts),
+      )
 
     // when
     val result =
@@ -134,7 +144,12 @@ class TransactionsViewModelTest {
     }
     advanceUntilIdle()
 
-    val source = TransactionsPagingSource(transactions, AllAccounts)
+    val source =
+      TransactionsPagingSource(
+        transactionDao = transactions,
+        tagsDao = tags,
+        spec = TransactionsSpec(AllAccounts),
+      )
 
     // when
     val result =
@@ -160,7 +175,11 @@ class TransactionsViewModelTest {
     advanceUntilIdle()
 
     val source =
-      TransactionsPagingSource(dao = transactions, spec = SpecificAccount(AccountId("a")))
+      TransactionsPagingSource(
+        transactionDao = transactions,
+        tagsDao = tags,
+        spec = TransactionsSpec(SpecificAccount(AccountId("a"))),
+      )
 
     // when
     val result =
@@ -172,6 +191,38 @@ class TransactionsViewModelTest {
       .withData(ID_A)
       .withPrevKey(null)
       .withNextKey(null) // No more pages since we loaded fewer items than page size
+  }
+
+  @Test
+  fun `Transactions for a specific tag`() = runTest {
+    // given
+    buildViewModel(AllAccounts)
+    tags.insert(id = TagId("food"), tag = "food", color = null, description = null)
+    with(transactions) {
+      insertTransaction(id = "a", account = "a", category = "a", payee = "a", notes = "lunch #food")
+      insertTransaction(id = "b", account = "b", category = "b", payee = "b", notes = "no tag here")
+      insertTransaction(id = "c", account = "c", category = "c", payee = "c", notes = "#foodie")
+      insertTransaction(id = "d", account = "c", category = "c", payee = "c", notes = "#FOOD again")
+    }
+    advanceUntilIdle()
+
+    val source =
+      TransactionsPagingSource(
+        transactionDao = transactions,
+        tagsDao = tags,
+        spec = TransactionsSpec(tagSpec = TagSpec.SpecificTag(TagId("food"))),
+      )
+
+    // when
+    val result =
+      source.load(LoadParams.Refresh(key = null, loadSize = 50, placeholdersEnabled = false))
+
+    // then - only the two exact, case-insensitive #food matches; #foodie is excluded
+    assertThat(result)
+      .isPage()
+      .withData(ID_D, ID_A)
+      .withPrevKey(expected = null)
+      .withNextKey(expected = null)
   }
 
   @Test
@@ -188,7 +239,12 @@ class TransactionsViewModelTest {
     }
     advanceUntilIdle()
 
-    val pagingSource = TransactionsPagingSource(transactions, AllAccounts)
+    val pagingSource =
+      TransactionsPagingSource(
+        transactionDao = transactions,
+        tagsDao = tags,
+        spec = TransactionsSpec(AllAccounts),
+      )
 
     // when
     val result =
@@ -216,7 +272,12 @@ class TransactionsViewModelTest {
     }
     advanceUntilIdle()
 
-    val source = TransactionsPagingSource(transactions, AllAccounts)
+    val source =
+      TransactionsPagingSource(
+        transactionDao = transactions,
+        tagsDao = tags,
+        spec = TransactionsSpec(AllAccounts),
+      )
 
     // when - load first page with size 2
     val firstPage =

--- a/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/LoadedAccount.kt
+++ b/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/LoadedAccount.kt
@@ -9,5 +9,7 @@ sealed interface LoadedAccount {
 
   data object AllAccounts : LoadedAccount
 
-  data class SpecificAccount(val account: Accounts) : LoadedAccount
+  @JvmInline value class SpecificAccount(val account: Accounts) : LoadedAccount
+
+  @JvmInline value class SpecificTag(val tag: String) : LoadedAccount
 }

--- a/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsPagingSource.kt
+++ b/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsPagingSource.kt
@@ -1,16 +1,27 @@
 package aktual.budget.transactions.vm
 
+import aktual.budget.db.dao.TagsDao
 import aktual.budget.db.dao.TransactionDao
 import aktual.budget.model.AccountSpec
+import aktual.budget.model.TagId
+import aktual.budget.model.TagSpec
 import aktual.budget.model.TransactionId
+import aktual.budget.model.TransactionsSpec
+import aktual.budget.model.notesContainTag
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.CancellationException
 
 internal class TransactionsPagingSource(
-  private val dao: TransactionDao,
-  private val spec: AccountSpec,
+  private val transactionDao: TransactionDao,
+  private val tagsDao: TagsDao,
+  private val spec: TransactionsSpec,
 ) : PagingSource<Int, TransactionId>() {
+  // A #tag match can't be expressed as a SQL offset query, so for tag-filtered specs we resolve the
+  // full ordered id list once and page over it in memory. Cached for this source's lifetime — a new
+  // source is created whenever the data is invalidated.
+  private var filteredIds: List<TransactionId>? = null
+
   override suspend fun load(params: LoadParams<Int>): LoadResult<Int, TransactionId> =
     try {
       // Start from page 0 if no key provided
@@ -19,9 +30,14 @@ internal class TransactionsPagingSource(
       val limit = params.loadSize.toLong()
 
       val transactionIds =
-        when (spec) {
-          AccountSpec.AllAccounts -> dao.getIdsPaged(limit, offset)
-          is AccountSpec.SpecificAccount -> dao.getIdsByAccountPaged(spec.id, limit, offset)
+        when (val tagSpec = spec.tagSpec) {
+          TagSpec.AllTags -> loadPage(limit, offset)
+          is TagSpec.SpecificTag -> {
+            val ids = filteredIds ?: loadFilteredIds(tagSpec.id).also { filteredIds = it }
+            val from = offset.toInt().coerceIn(0, ids.size)
+            val to = (from + limit.toInt()).coerceAtMost(ids.size)
+            ids.subList(from, to).toList()
+          }
         }
 
       LoadResult.Page(
@@ -34,6 +50,26 @@ internal class TransactionsPagingSource(
     } catch (e: Exception) {
       LoadResult.Error(e)
     }
+
+  private suspend fun loadPage(limit: Long, offset: Long): List<TransactionId> =
+    when (val accountSpec = spec.accountSpec) {
+      AccountSpec.AllAccounts -> transactionDao.getIdsPaged(limit, offset)
+      is AccountSpec.SpecificAccount ->
+        transactionDao.getIdsByAccountPaged(accountSpec.id, limit, offset)
+    }
+
+  private suspend fun loadFilteredIds(id: TagId): List<TransactionId> {
+    val tagName = tagsDao.getTag(id)?.tag ?: return emptyList()
+    val rows =
+      when (val accountSpec = spec.accountSpec) {
+        AccountSpec.AllAccounts -> transactionDao.getIdsAndNotes()
+        is AccountSpec.SpecificAccount -> transactionDao.getIdsAndNotesByAccount(accountSpec.id)
+      }
+    return rows.mapNotNull { row ->
+      val notes = row.notes
+      row.id.takeIf { notes != null && notesContainTag(notes, tagName) }
+    }
+  }
 
   override fun getRefreshKey(state: PagingState<Int, TransactionId>): Int? {
     // Try to find the page key of the closest item to the current scroll position

--- a/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsPagingSource.kt
+++ b/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsPagingSource.kt
@@ -31,7 +31,10 @@ internal class TransactionsPagingSource(
 
       val transactionIds =
         when (val tagSpec = spec.tagSpec) {
-          TagSpec.AllTags -> loadPage(limit, offset)
+          TagSpec.AllTags -> {
+            loadPage(limit, offset)
+          }
+
           is TagSpec.SpecificTag -> {
             val ids = filteredIds ?: loadFilteredIds(tagSpec.id).also { filteredIds = it }
             val from = offset.toInt().coerceIn(0, ids.size)

--- a/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsViewModel.kt
+++ b/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsViewModel.kt
@@ -90,6 +90,8 @@ class TransactionsViewModel(
         }
     }
 
+    // TODO: also handle tag spec
+
     // Invalidate PagingSource when transaction data changes.
     // Ignore the first item from the flow, that'll be the initial table state.
     viewModelScope.launch {

--- a/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsViewModel.kt
+++ b/aktual-budget/transactions/vm/src/commonMain/kotlin/aktual/budget/transactions/vm/TransactionsViewModel.kt
@@ -2,6 +2,7 @@ package aktual.budget.transactions.vm
 
 import aktual.budget.db.dao.AccountDao
 import aktual.budget.db.dao.PreferencesDao
+import aktual.budget.db.dao.TagsDao
 import aktual.budget.db.dao.TransactionDao
 import aktual.budget.db.transactions.GetById
 import aktual.budget.model.AccountSpec
@@ -9,12 +10,14 @@ import aktual.budget.model.Amount
 import aktual.budget.model.BudgetLocalPreferences
 import aktual.budget.model.DbMetadata
 import aktual.budget.model.SyncedPrefKey
+import aktual.budget.model.TagSpec
 import aktual.budget.model.TransactionId
 import aktual.budget.model.TransactionsFormat
 import aktual.budget.model.TransactionsSpec
 import aktual.budget.transactions.vm.LoadedAccount.AllAccounts
 import aktual.budget.transactions.vm.LoadedAccount.Loading
 import aktual.budget.transactions.vm.LoadedAccount.SpecificAccount
+import aktual.budget.transactions.vm.LoadedAccount.SpecificTag
 import aktual.di.BudgetScope
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
@@ -51,6 +54,7 @@ class TransactionsViewModel(
   private val prefs: BudgetLocalPreferences,
   private val accountDao: AccountDao,
   private val transactionDao: TransactionDao,
+  private val tagsDao: TagsDao,
   private val preferencesDao: PreferencesDao,
 ) : ViewModel(), TransactionStateSource, TransactionIdSource {
   @AssistedFactory
@@ -80,17 +84,25 @@ class TransactionsViewModel(
       .cachedIn(viewModelScope)
 
   init {
-    when (val s = spec.accountSpec) {
-      is AccountSpec.AllAccounts -> mutableLoadedAccount.update { AllAccounts }
-
-      is AccountSpec.SpecificAccount ->
+    // A tag-filtered screen titles itself after the tag; otherwise the title follows the account.
+    when (val tagSpec = spec.tagSpec) {
+      is TagSpec.SpecificTag ->
         viewModelScope.launch {
-          val account = accountDao[s.id] ?: error("No account matching $s")
-          mutableLoadedAccount.update { SpecificAccount(account) }
+          val name = tagsDao.getTag(tagSpec.id)?.tag
+          mutableLoadedAccount.update { if (name != null) SpecificTag(name) else AllAccounts }
+        }
+
+      is TagSpec.AllTags ->
+        when (val s = spec.accountSpec) {
+          is AccountSpec.AllAccounts -> mutableLoadedAccount.update { AllAccounts }
+
+          is AccountSpec.SpecificAccount ->
+            viewModelScope.launch {
+              val account = accountDao[s.id] ?: error("No account matching $s")
+              mutableLoadedAccount.update { SpecificAccount(account) }
+            }
         }
     }
-
-    // TODO: also handle tag spec
 
     // Invalidate PagingSource when transaction data changes.
     // Ignore the first item from the flow, that'll be the initial table state.
@@ -151,7 +163,7 @@ class TransactionsViewModel(
   }
 
   private fun buildPagingSource() =
-    TransactionsPagingSource(transactionDao, spec.accountSpec).also { currentPagingSource = it }
+    TransactionsPagingSource(transactionDao, tagsDao, spec).also { currentPagingSource = it }
 
   private companion object {
     val TransactionFormatKey = DbMetadata.enumKey<TransactionsFormat>("transactionFormat")

--- a/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/MaterialIconPreviews.kt
+++ b/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/MaterialIconPreviews.kt
@@ -73,6 +73,7 @@ private val materialIcons =
       Security,
       SelectAll,
       Settings,
+      Shuffle,
       Sort,
       SpaceBar,
       Speed125,

--- a/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/Shuffle.kt
+++ b/aktual-core/icons/src/commonMain/kotlin/aktual/core/icons/material/Shuffle.kt
@@ -1,0 +1,42 @@
+@file:Suppress("UnusedReceiverParameter")
+
+package aktual.core.icons.material
+
+import aktual.core.icons.material.internal.materialIcon
+import aktual.core.icons.material.internal.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+val MaterialIcons.Shuffle: ImageVector by lazy {
+  materialIcon(name = "Shuffle", viewportSize = 960f) {
+    materialPath {
+      moveTo(560f, 800f)
+      verticalLineToRelative(-80f)
+      horizontalLineToRelative(104f)
+      lineTo(537f, 593f)
+      lineToRelative(57f, -57f)
+      lineToRelative(126f, 126f)
+      verticalLineToRelative(-102f)
+      horizontalLineToRelative(80f)
+      verticalLineToRelative(240f)
+      horizontalLineTo(560f)
+      close()
+      moveToRelative(-344f, 0f)
+      lineToRelative(-56f, -56f)
+      lineToRelative(504f, -504f)
+      horizontalLineTo(560f)
+      verticalLineToRelative(-80f)
+      horizontalLineToRelative(240f)
+      verticalLineToRelative(240f)
+      horizontalLineToRelative(-80f)
+      verticalLineToRelative(-104f)
+      lineTo(216f, 800f)
+      close()
+      moveToRelative(151f, -377f)
+      lineTo(160f, 216f)
+      lineToRelative(56f, -56f)
+      lineToRelative(207f, 207f)
+      lineToRelative(-56f, 56f)
+      close()
+    }
+  }
+}

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -24,7 +24,7 @@
   <string name="tags_create_description_label">Description</string>
   <string name="tags_create_description_placeholder">What is this tag for?</string>
   <string name="tags_create_color_label">Color</string>
-  <string name="tags_create_color_placeholder">#aabbcc</string>
+  <string name="tags_create_color_placeholder">#AABBCC</string>
   <string name="tags_create_color_advanced">Advanced color options</string>
   <string name="tags_create_color_invalid">Invalid color code</string>
   <string name="tags_create_save">Save</string>

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -40,4 +40,8 @@
     <item quantity="one">%1$d match</item>
     <item quantity="other">%1$d matches</item>
   </plurals>
+  <plurals name="tags_num_transactions">
+    <item quantity="one">%1$d transaction</item>
+    <item quantity="other">%1$d transactions</item>
+  </plurals>
 </resources>

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -26,6 +26,7 @@
   <string name="tags_create_color_label">Color</string>
   <string name="tags_create_color_placeholder">#AABBCC</string>
   <string name="tags_create_color_advanced">Advanced color options</string>
+  <string name="tags_create_color_random">Random color</string>
   <string name="tags_create_color_invalid">Invalid color code</string>
   <string name="tags_create_save">Save</string>
   <string name="tags_save_failure_title">Couldn\'t save tag</string>

--- a/aktual-core/nav/src/commonMain/kotlin/aktual/core/nav/BudgetNavigators.kt
+++ b/aktual-core/nav/src/commonMain/kotlin/aktual/core/nav/BudgetNavigators.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Immutable
 @Immutable
 class TransactionsNavigator(private val stack: NavStack<BudgetNavKey>) {
   operator fun invoke() = stack.replaceAll(TransactionsNavRoute)
+
+  operator fun invoke(id: TagId) = stack.replaceAll(TransactionsWithTagNavRoute(id))
 }
 
 @Immutable

--- a/aktual-core/nav/src/commonMain/kotlin/aktual/core/nav/BudgetNavigators.kt
+++ b/aktual-core/nav/src/commonMain/kotlin/aktual/core/nav/BudgetNavigators.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Immutable
 class TransactionsNavigator(private val stack: NavStack<BudgetNavKey>) {
   operator fun invoke() = stack.replaceAll(TransactionsNavRoute)
 
-  operator fun invoke(id: TagId) = stack.replaceAll(TransactionsWithTagNavRoute(id))
+  operator fun invoke(id: TagId) = stack.push(TransactionsWithTagNavRoute(id))
 }
 
 @Immutable

--- a/aktual-core/nav/src/commonMain/kotlin/aktual/core/nav/BudgetRoutes.kt
+++ b/aktual-core/nav/src/commonMain/kotlin/aktual/core/nav/BudgetRoutes.kt
@@ -9,6 +9,11 @@ import kotlinx.serialization.Serializable
 
 @Immutable @Serializable data object TransactionsNavRoute : BudgetNavKey.Transactions
 
+@Immutable
+@Serializable
+@JvmInline
+value class TransactionsWithTagNavRoute(val id: TagId) : BudgetNavKey.Transactions
+
 @Immutable @Serializable data object ReportsListNavRoute : BudgetNavKey.Reports
 
 @JvmInline


### PR DESCRIPTION
Adds the ability to view the transactions carrying a given tag, and surfaces per-tag transaction counts.

- Tag list count pill is now tappable and navigates (push, so back returns to the list) to a tag-filtered transactions screen.
- Per-tag transaction counts are computed from notes (`#tag` tokenizer mirroring upstream), replacing the `numTransactions = 0` stub.
- `TransactionsPagingSource` resolves the full ordered id list once and pages it in memory for tag specs (SQL has no regex), titled after the tag.
- Adds a "randomise colour" button to the tag colour picker (Shuffle icon) — presets in grid mode, any colour in advanced mode.
