### PR TITLE
Clarify tag-matching contract and add tests

### DIFF
--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TagMatching.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TagMatching.kt
@@ -1,9 +1,11 @@
 package aktual.budget.model
 
-// A tag (#name) is "linked" to a transaction when its token appears in the transaction notes,
-// bounded by start/whitespace on the left and whitespace, another '#', or end-of-string on the
-// right. Matching is case-insensitive. Mirrors the hasTags filter in upstream Actual
-// (packages/loot-core/src/server/rules/condition.ts) and the tag extraction in tags/app.ts.
+// A tag (#name) is "linked" to a transaction when its token appears in the transaction notes.
+// A token is a '#' not immediately preceded by another '#' (so '##' is skipped), followed by one
+// or more non-'#', non-whitespace characters. Note this does not require a whitespace boundary on
+// the left, so "word#tag" still matches "tag". Matching is case-insensitive. Mirrors the hasTags
+// filter in upstream Actual (packages/loot-core/src/server/rules/condition.ts) and the tag
+// extraction in tags/app.ts, both of which use this exact pattern.
 private val TAG_TOKEN = Regex("""(?<!#)#([^#\s]+)""")
 
 // The distinct tag names (lowercased, without the leading '#') referenced in [notes].

--- a/aktual-budget/model/src/commonTest/kotlin/aktual/budget/model/TagMatchingTest.kt
+++ b/aktual-budget/model/src/commonTest/kotlin/aktual/budget/model/TagMatchingTest.kt
@@ -1,0 +1,91 @@
+package aktual.budget.model
+
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEmpty
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+// Mostly pulled from packages/loot-core/src/server/transactions/transaction-rules.test.ts
+class TagMatchingTest {
+  @Test
+  fun `No tags`() {
+    assertThat(tagsInNotes("")).isEmpty()
+    assertThat(tagsInNotes("just some plain notes")).isEmpty()
+    assertThat(tagsInNotes("a # b")).isEmpty()
+  }
+
+  @Test
+  fun `Single tag`() {
+    assertThat(tagsInNotes("#food")).containsExactlyInAnyOrder("food")
+    assertThat(tagsInNotes("lunch #food today")).containsExactlyInAnyOrder("food")
+  }
+
+  @Test
+  fun `Multiple tags`() {
+    assertThat(tagsInNotes("#food #travel groceries #home"))
+      .containsExactlyInAnyOrder("food", "travel", "home")
+  }
+
+  @Test
+  fun `Tags are lowercased and de-duplicated`() {
+    assertThat(tagsInNotes("#Food #FOOD #food")).containsExactlyInAnyOrder("food")
+  }
+
+  @Test
+  fun `Tag terminated by another hash`() {
+    assertThat(tagsInNotes("#food#travel")).containsExactlyInAnyOrder("food", "travel")
+  }
+
+  @Test
+  fun `Double hash is skipped`() {
+    // '##' does not start a tag (lookbehind blocks it), matching upstream Actual
+    assertThat(tagsInNotes("##food")).isEmpty()
+    assertThat(tagsInNotes("a ##comment #real")).containsExactlyInAnyOrder("real")
+  }
+
+  @Test
+  fun `No left whitespace boundary required`() {
+    // Mirrors upstream: "word#tag" still matches the tag
+    assertThat(tagsInNotes("ref#food purchase")).containsExactlyInAnyOrder("food")
+  }
+
+  @Test
+  fun `Tag bounded by punctuation is not split`() {
+    // Whitespace and '#' are the only terminators, so trailing punctuation is part of the token
+    assertThat(tagsInNotes("#food, please")).containsExactlyInAnyOrder("food,")
+  }
+
+  @Test
+  fun `Tag content is a whole token, not a substring`() {
+    // "#tagContent" must not satisfy the tag "tag" (mirrors upstream hasTags)
+    assertThat(tagsInNotes("Follow up #tagContent")).containsExactlyInAnyOrder("tagcontent")
+    assertThat(notesContainTag("Follow up #tagContent", "tag")).isFalse()
+  }
+
+  @Test
+  fun `Tag containing regex-special characters`() {
+    // Upstream has a "#$Bug_Test" case; '$' must be treated literally
+    assertThat(tagsInNotes("Follow up #\$Bug_Test issue")).containsExactlyInAnyOrder("\$bug_test")
+    assertThat(notesContainTag("Follow up #\$Bug_Test issue", "\$bug_test")).isTrue()
+  }
+
+  @Test
+  fun `notesContainTag is case-insensitive`() {
+    assertThat(notesContainTag("lunch #Food", "food")).isTrue()
+    assertThat(notesContainTag("lunch #food", "FOOD")).isTrue()
+  }
+
+  @Test
+  fun `notesContainTag false when absent`() {
+    assertThat(notesContainTag("lunch #food", "travel")).isFalse()
+    assertThat(notesContainTag("", "food")).isFalse()
+  }
+
+  @Test
+  fun `notesContainTag matches word-adjacent tag`() {
+    assertThat(notesContainTag("ref#food", "food")).isTrue()
+    assertThat(notesContainTag("##food", "food")).isFalse()
+  }
+}


### PR DESCRIPTION
The comment on the tag-token regex claimed a start/whitespace boundary on the left that the pattern doesn't actually enforce (the lookbehind only blocks `##`). Reword it to describe the real contract — `word#tag` does match — which is consistent with upstream Actual, where both `discoverTags` (`tags/app.ts`) and the `hasTags` filter (`rules/condition.ts`) use this exact pattern.

Adds `TagMatchingTest` covering `tagsInNotes` and `notesContainTag`. Several cases are adapted from upstream's `transaction-rules.test.ts` (whole-token match, multiple tags, `$`-prefixed tag, `##` skipping); the rest are Aktual-specific edge cases.