### PR TITLE
Add sort options to the tags list

### DIFF
--- a/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TagSort.kt
+++ b/aktual-budget/model/src/commonMain/kotlin/aktual/budget/model/TagSort.kt
@@ -1,0 +1,30 @@
+package aktual.budget.model
+
+import alakazam.kotlin.SerializableByString
+import kotlinx.collections.immutable.toImmutableList
+
+data class TagSort(val field: Field, val direction: Direction) {
+  companion object {
+    val Default = TagSort(Field.Default, Direction.Default)
+  }
+
+  enum class Field(override val value: String) : SerializableByString {
+    Name("name"),
+    Usage("usage");
+
+    companion object {
+      val Default = Name
+      val Entries = entries.toImmutableList()
+    }
+  }
+
+  enum class Direction(override val value: String) : SerializableByString {
+    Ascending("ascending"),
+    Descending("descending");
+
+    companion object {
+      val Default = Ascending
+      val Entries = entries.toImmutableList()
+    }
+  }
+}

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsAction.kt
@@ -1,6 +1,7 @@
 package aktual.budget.tags.ui.list
 
 import aktual.budget.model.TagId
+import aktual.budget.model.TagSort
 import androidx.compose.runtime.Immutable
 
 @Immutable internal sealed interface ListTagsAction
@@ -22,6 +23,8 @@ internal data object CreateTag : ListTagsAction
 @JvmInline internal value class ViewTransactions(val id: TagId) : ListTagsAction
 
 @JvmInline internal value class DeleteTag(val id: TagId) : ListTagsAction
+
+@JvmInline internal value class SetSort(val sort: TagSort) : ListTagsAction
 
 @Immutable
 internal fun interface ListTagsActionHandler {

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/ListTagsScreen.kt
@@ -1,6 +1,7 @@
 package aktual.budget.tags.ui.list
 
 import aktual.budget.model.TagId
+import aktual.budget.model.TagSort
 import aktual.budget.tags.vm.list.Empty
 import aktual.budget.tags.vm.list.Failure
 import aktual.budget.tags.vm.list.ListTagsEvent
@@ -14,6 +15,7 @@ import aktual.core.icons.material.MaterialIcons
 import aktual.core.icons.material.Refresh
 import aktual.core.icons.material.Search
 import aktual.core.icons.material.SearchOff
+import aktual.core.icons.material.Sort
 import aktual.core.l10n.Plurals
 import aktual.core.l10n.Strings
 import aktual.core.nav.EditTagNavigator
@@ -122,6 +124,7 @@ internal fun ListTagsScreen(
         is EditTag -> toEdit(action.id)
         is DeleteTag -> viewModel.delete(action.id)
         is ViewTransactions -> toTransactions(action.id)
+        is SetSort -> viewModel.setSort(action.sort)
       }
     },
   )
@@ -140,6 +143,18 @@ private fun ListTagsScaffold(
   val successState = state as? Success
 
   val isSearchActive = successState?.isSearchActive == true
+  var showSortDialog by remember { mutableStateOf(false) }
+
+  if (showSortDialog) {
+    TagSortDialog(
+      sort = successState?.sort ?: TagSort.Default,
+      onConfirm = { sort ->
+        onAction(SetSort(sort))
+        showSortDialog = false
+      },
+      onDismiss = { showSortDialog = false },
+    )
+  }
 
   Scaffold(
     modifier = modifier.fillMaxSize().imePadding(),
@@ -149,6 +164,13 @@ private fun ListTagsScaffold(
         colors = colors.transparentTopAppBarColors(),
         title = { Title(isSearchActive, successState, onAction) },
         actions = {
+          if (successState != null) {
+            BareIconButton(
+              imageVector = MaterialIcons.Sort,
+              contentDescription = Strings.tagsSort,
+              onClick = { showSortDialog = true },
+            )
+          }
           BareIconButton(
             imageVector = if (isSearchActive) MaterialIcons.SearchOff else MaterialIcons.Search,
             contentDescription = Strings.tagsFilter,
@@ -339,9 +361,24 @@ private fun TagsList(
 
 private class ListTagsStateProvider :
   ColoredParameterProvider<ListTagsState>(
-    Success(tags = TagsPreview.all, filterText = "", isSearchActive = false),
-    Success(tags = TagsPreview.all, filterText = "gro", isSearchActive = true),
-    Success(tags = persistentListOf(), filterText = "xyz", isSearchActive = true),
+    Success(
+      tags = TagsPreview.all,
+      filterText = "",
+      isSearchActive = false,
+      sort = TagSort.Default,
+    ),
+    Success(
+      tags = TagsPreview.all,
+      filterText = "gro",
+      isSearchActive = true,
+      sort = TagSort.Default,
+    ),
+    Success(
+      tags = persistentListOf(),
+      filterText = "xyz",
+      isSearchActive = true,
+      sort = TagSort.Default,
+    ),
     Empty,
     Loading,
     Failure("Database connection lost"),

--- a/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagSortDialog.kt
+++ b/aktual-budget/tags/ui/src/commonMain/kotlin/aktual/budget/tags/ui/list/TagSortDialog.kt
@@ -1,0 +1,137 @@
+package aktual.budget.tags.ui.list
+
+import aktual.budget.model.TagSort
+import aktual.core.l10n.Strings
+import aktual.core.theme.Colors
+import aktual.core.ui.AktualAlertDialog
+import aktual.core.ui.AktualTheme.colors
+import aktual.core.ui.AktualTheme.typography
+import aktual.core.ui.ColoredParameters
+import aktual.core.ui.NormalTextButton
+import aktual.core.ui.PreviewWithColors
+import aktual.core.ui.radioButton
+import alakazam.compose.VerticalSpacer
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+
+@Composable
+internal fun TagSortDialog(
+  sort: TagSort,
+  onConfirm: (TagSort) -> Unit,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var field by remember { mutableStateOf(sort.field) }
+  var direction by remember { mutableStateOf(sort.direction) }
+
+  AktualAlertDialog(
+    modifier = modifier,
+    title = Strings.tagsSort,
+    onDismissRequest = onDismiss,
+    buttons = {
+      NormalTextButton(
+        text = Strings.tagsSortApply,
+        onClick = { onConfirm(TagSort(field, direction)) },
+      )
+    },
+  ) {
+    SortSection(
+      label = Strings.tagsSortField,
+      options = TagSort.Field.Entries,
+      selected = field,
+      name = { it.label() },
+      onSelect = { field = it },
+    )
+
+    VerticalSpacer(10.dp)
+
+    SortSection(
+      label = Strings.tagsSortDirection,
+      options = TagSort.Direction.Entries,
+      selected = direction,
+      name = { it.label() },
+      onSelect = { direction = it },
+    )
+  }
+}
+
+@Composable
+private fun <T> ColumnScope.SortSection(
+  label: String,
+  options: ImmutableList<T>,
+  selected: T,
+  name: @Composable (T) -> String,
+  onSelect: (T) -> Unit,
+) {
+  Text(
+    modifier = Modifier.fillMaxWidth(),
+    text = label,
+    style = typography.labelLarge,
+    color = colors.pageTextSubdued,
+  )
+
+  Column(Modifier.fillMaxWidth().selectableGroup()) {
+    for (option in options) {
+      SortOptionRow(
+        isSelected = option == selected,
+        onClick = { onSelect(option) },
+        name = name(option),
+      )
+    }
+  }
+}
+
+@Composable
+private fun SortOptionRow(isSelected: Boolean, onClick: () -> Unit, name: String) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .selectable(selected = isSelected, onClick = onClick, role = null)
+        .padding(vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    RadioButton(selected = isSelected, onClick = null, colors = colors.radioButton())
+    Text(text = name, style = typography.bodyLarge, color = colors.pageText)
+  }
+}
+
+@Composable
+private fun TagSort.Field.label(): String =
+  when (this) {
+    TagSort.Field.Name -> Strings.tagsSortFieldName
+    TagSort.Field.Usage -> Strings.tagsSortFieldUsage
+  }
+
+@Composable
+private fun TagSort.Direction.label(): String =
+  when (this) {
+    TagSort.Direction.Ascending -> Strings.tagsSortDirectionAscending
+    TagSort.Direction.Descending -> Strings.tagsSortDirectionDescending
+  }
+
+@Preview
+@Composable
+private fun PreviewTagSortDialog(@PreviewParameter(ColoredParameters::class) colors: Colors) =
+  PreviewWithColors(colors) {
+    TagSortDialog(sort = TagSort.Default, onConfirm = {}, onDismiss = {})
+  }

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/edit/EditTagViewModelTest.kt
@@ -10,8 +10,8 @@ import aktual.budget.model.TagId
 import aktual.budget.tags.vm.insertTag
 import aktual.budget.tags.vm.tombstoneTag
 import aktual.core.model.UuidGenerator
-import aktual.prefs.AppPreferences
-import aktual.prefs.AppPreferencesImpl
+import aktual.prefs.TagPreferences
+import aktual.prefs.TagPreferencesImpl
 import aktual.test.TestSyncController
 import aktual.test.assertThatNextEmission
 import aktual.test.buildPreferences
@@ -52,7 +52,7 @@ class EditTagViewModelTest {
 
   @Test
   fun `New tag seeds its colour from the last used colour`() = runDatabaseTest { scope ->
-    val preferences = AppPreferencesImpl(scope.buildPreferences())
+    val preferences = TagPreferencesImpl(scope.buildPreferences())
     preferences.lastUsedTagColor.set("#AABBCC")
 
     val viewModel = createViewModel(scope, id = null, preferences = preferences)
@@ -199,7 +199,7 @@ class EditTagViewModelTest {
   @Test
   fun `Saving a coloured tag remembers the colour for the next new tag`() =
     runDatabaseTest { scope ->
-      val preferences = AppPreferencesImpl(scope.buildPreferences())
+      val preferences = TagPreferencesImpl(scope.buildPreferences())
       val viewModel = createViewModel(scope, id = null, preferences = preferences)
       viewModel.awaitLoaded()
 
@@ -358,7 +358,7 @@ class EditTagViewModelTest {
     id: TagId?,
     uuid: UuidGenerator = UuidGenerator { GENERATED_ID },
     sync: BudgetSyncController = TestSyncController(),
-    preferences: AppPreferences = AppPreferencesImpl(scope.buildPreferences()),
+    preferences: TagPreferences = TagPreferencesImpl(scope.buildPreferences()),
   ): EditTagViewModel {
     tagsDao = TagsDao(this)
     return EditTagViewModel(

--- a/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
+++ b/aktual-budget/tags/vm/src/androidHostTest/kotlin/aktual/budget/tags/vm/list/ListTagsViewModelTest.kt
@@ -7,8 +7,12 @@ import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.LocalChange
 import aktual.budget.model.MessageValue
 import aktual.budget.model.TagId
+import aktual.budget.model.TagSort
 import aktual.budget.tags.vm.insertTag
+import aktual.prefs.TagPreferences
+import aktual.prefs.TagPreferencesImpl
 import aktual.test.TestSyncController
+import aktual.test.buildPreferences
 import aktual.test.runDatabaseTest
 import alakazam.test.TestCoroutineContexts
 import alakazam.test.standardDispatcher
@@ -259,9 +263,63 @@ class ListTagsViewModelTest {
       }
     }
 
+  @Test
+  fun `Sorts alphabetically by name ascending by default`() = runDatabaseTest { scope ->
+    insertTag(id = "rent-id", tag = "rent")
+    insertTag(id = "apple-id", tag = "apple")
+    insertTag(id = "mango-id", tag = "Mango")
+
+    val viewModel = createViewModel(scope)
+
+    viewModel.state.test {
+      val success = awaitItem() as Success
+      // case-insensitive A-Z, regardless of insertion order
+      assertThat(success)
+        .prop(Success::tags)
+        .extracting(TagItem::tag)
+        .containsExactly("apple", "Mango", "rent")
+      assertThat(success.sort).isEqualTo(TagSort(TagSort.Field.Name, TagSort.Direction.Ascending))
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `setSort persists the choice and re-sorts the list`() = runDatabaseTest { scope ->
+    insertTag(id = "apple-id", tag = "apple")
+    insertTag(id = "rent-id", tag = "rent")
+
+    val preferences = TagPreferencesImpl(scope.buildPreferences())
+    val viewModel = createViewModel(scope, preferences = preferences)
+
+    viewModel.state.test {
+      // starts ascending
+      assertThat(awaitItem() as Success)
+        .prop(Success::tags)
+        .extracting(TagItem::tag)
+        .containsExactly("apple", "rent")
+
+      // switching to descending flips the order
+      viewModel.setSort(TagSort(TagSort.Field.Name, TagSort.Direction.Descending))
+      var success = awaitItem() as Success
+      while (success.sort.direction != TagSort.Direction.Descending) {
+        success = awaitItem() as Success
+      }
+      assertThat(success)
+        .prop(Success::tags)
+        .extracting(TagItem::tag)
+        .containsExactly("rent", "apple")
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    // and the choice is remembered
+    assertThat(preferences.sortField.get()).isEqualTo(TagSort.Field.Name)
+    assertThat(preferences.sortDirection.get()).isEqualTo(TagSort.Direction.Descending)
+  }
+
   private fun BudgetDatabase.createViewModel(
     scope: TestScope,
     sync: BudgetSyncController = TestSyncController(),
+    preferences: TagPreferences = TagPreferencesImpl(scope.buildPreferences()),
   ) =
     ListTagsViewModel(
       savedState = SavedStateHandle(),
@@ -269,6 +327,7 @@ class ListTagsViewModelTest {
       transactionDao =
         TransactionDao(database = this, contexts = TestCoroutineContexts(scope.standardDispatcher)),
       syncController = sync,
+      preferences = preferences,
     )
 
   private class FailingSyncController : BudgetSyncController {

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/edit/EditTagViewModel.kt
@@ -13,7 +13,7 @@ import aktual.budget.tags.vm.toColorOrNull
 import aktual.budget.tags.vm.toHex
 import aktual.core.model.UuidGenerator
 import aktual.di.BudgetScope
-import aktual.prefs.AppPreferences
+import aktual.prefs.TagPreferences
 import alakazam.kotlin.requireMessage
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
@@ -51,7 +51,7 @@ class EditTagViewModel(
   private val tagsDao: TagsDao,
   private val uuidGenerator: UuidGenerator,
   private val syncController: BudgetSyncController,
-  private val preferences: AppPreferences,
+  private val preferences: TagPreferences,
 ) : ViewModel() {
   private val mutableLoaded = MutableStateFlow<Loaded?>(null)
   private val mutableFailure = MutableStateFlow<EditTagState.Failure?>(null)

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsState.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsState.kt
@@ -1,5 +1,6 @@
 package aktual.budget.tags.vm.list
 
+import aktual.budget.model.TagSort
 import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.ImmutableList
 
@@ -16,4 +17,5 @@ data class Success(
   val tags: ImmutableList<TagItem>,
   val filterText: String,
   val isSearchActive: Boolean,
+  val sort: TagSort,
 ) : ListTagsState

--- a/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
+++ b/aktual-budget/tags/vm/src/commonMain/kotlin/aktual/budget/tags/vm/list/ListTagsViewModel.kt
@@ -5,10 +5,12 @@ import aktual.budget.db.dao.TagsDao
 import aktual.budget.db.dao.TransactionDao
 import aktual.budget.model.BudgetSyncController
 import aktual.budget.model.TagId
+import aktual.budget.model.TagSort
 import aktual.budget.model.tagsInNotes
 import aktual.budget.model.tombstone
 import aktual.budget.model.untombstone
 import aktual.di.BudgetScope
+import aktual.prefs.TagPreferences
 import alakazam.kotlin.requireMessage
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
@@ -49,6 +51,7 @@ class ListTagsViewModel(
   private val tagsDao: TagsDao,
   private val transactionDao: TransactionDao,
   private val syncController: BudgetSyncController,
+  private val preferences: TagPreferences,
 ) : ViewModel() {
   @AssistedFactory
   @ViewModelAssistedFactoryKey(ListTagsViewModel::class)
@@ -86,12 +89,16 @@ class ListTagsViewModel(
       val failure by mutableFailure.collectAsState()
       val filterText by filterText.collectAsState()
       val isSearchActive by isSearchActive.collectAsState()
+      val sortField by preferences.sortField.asFlow().collectAsState(TagSort.Field.Default)
+      val sortDirection by
+        preferences.sortDirection.asFlow().collectAsState(TagSort.Direction.Default)
       @Suppress("BracesOnWhenStatements")
       when {
         isLoading -> Loading
         failure != null -> Failure(failure)
         tags.isEmpty() -> Empty
-        else -> buildSuccessState(isSearchActive, tags, filterText)
+        else ->
+          buildSuccessState(isSearchActive, tags, filterText, TagSort(sortField, sortDirection))
       }
     }
 
@@ -201,18 +208,45 @@ class ListTagsViewModel(
     }
   }
 
+  fun setSort(sort: TagSort) {
+    viewModelScope.launch {
+      preferences.sortField.set(sort.field)
+      preferences.sortDirection.set(sort.direction)
+    }
+  }
+
   private fun buildSuccessState(
     isSearchActive: Boolean,
     tags: ImmutableList<TagItem>,
     filterText: String,
+    sort: TagSort,
   ): Success {
     val filtered =
       if (isSearchActive) {
-        tags.filter { tag -> filterText in tag }.toImmutableList()
+        tags.filter { tag -> filterText in tag }
       } else {
         tags
       }
-    return Success(tags = filtered, filterText = filterText, isSearchActive = isSearchActive)
+    val sorted = filtered.sortedWith(sort.comparator()).toImmutableList()
+    return Success(
+      tags = sorted,
+      filterText = filterText,
+      isSearchActive = isSearchActive,
+      sort = sort,
+    )
+  }
+
+  private fun TagSort.comparator(): Comparator<TagItem> {
+    val byField =
+      when (field) {
+        TagSort.Field.Name -> compareBy { it.tag.lowercase() }
+        TagSort.Field.Usage ->
+          compareBy<TagItem> { it.numTransactions }.thenBy { it.tag.lowercase() }
+      }
+    return when (direction) {
+      TagSort.Direction.Ascending -> byField
+      TagSort.Direction.Descending -> byField.reversed()
+    }
   }
 
   private operator fun TagItem.contains(query: String): Boolean {

--- a/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
+++ b/aktual-core/l10n/src/commonMain/composeResources/values/strings-budget-tags.xml
@@ -9,6 +9,14 @@
   <string name="tags_filter_placeholder">Filter tags…</string>
   <string name="tags_filter_clear">Clear filter</string>
   <string name="tags_create">Create tag</string>
+  <string name="tags_sort">Sort</string>
+  <string name="tags_sort_field">Sort by</string>
+  <string name="tags_sort_field_name">Name</string>
+  <string name="tags_sort_field_usage">Number of transactions</string>
+  <string name="tags_sort_direction">Order</string>
+  <string name="tags_sort_direction_ascending">Ascending</string>
+  <string name="tags_sort_direction_descending">Descending</string>
+  <string name="tags_sort_apply">Apply</string>
   <string name="tags_delete">Delete</string>
   <string name="tags_deleted">Deleted #%1$s</string>
   <string name="tags_deleted_undo">Undo</string>

--- a/aktual-prefs/impl/src/androidHostTest/kotlin/aktual/prefs/AppPreferencesTest.kt
+++ b/aktual-prefs/impl/src/androidHostTest/kotlin/aktual/prefs/AppPreferencesTest.kt
@@ -54,30 +54,6 @@ class AppPreferencesTest {
   }
 
   @Test
-  fun `Last used tag colour`() = runTest {
-    before()
-    with(preferences.lastUsedTagColor) {
-      asFlow().test {
-        // Given nothing has been stored yet
-        assertThatNextEmissionIsEqualTo(null)
-
-        // When a colour is stored
-        set("#AABBCC")
-
-        // Then it round-trips
-        assertThatNextEmissionIsEqualTo("#AABBCC")
-
-        // When cleared
-        delete()
-
-        // Then it's back to null
-        assertThatNextEmissionIsEqualTo(null)
-        cancelAndIgnoreRemainingEvents()
-      }
-    }
-  }
-
-  @Test
   fun `Nav grid order`() = runTest {
     before()
     with(preferences.navGridOrder) {

--- a/aktual-prefs/impl/src/androidHostTest/kotlin/aktual/prefs/TagPreferencesTest.kt
+++ b/aktual-prefs/impl/src/androidHostTest/kotlin/aktual/prefs/TagPreferencesTest.kt
@@ -1,0 +1,81 @@
+package aktual.prefs
+
+import aktual.budget.model.TagSort
+import aktual.test.assertThatNextEmissionIsEqualTo
+import aktual.test.buildPreferences
+import alakazam.test.unconfinedDispatcher
+import app.cash.turbine.test
+import kotlin.test.Test
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TagPreferencesTest {
+  private lateinit var preferences: TagPreferences
+
+  private fun TestScope.before() {
+    preferences = TagPreferencesImpl(buildPreferences(unconfinedDispatcher))
+  }
+
+  @Test
+  fun `Last used tag colour`() = runTest {
+    before()
+    with(preferences.lastUsedTagColor) {
+      asFlow().test {
+        // Given nothing has been stored yet
+        assertThatNextEmissionIsEqualTo(null)
+
+        // When a colour is stored
+        set("#AABBCC")
+
+        // Then it round-trips
+        assertThatNextEmissionIsEqualTo("#AABBCC")
+
+        // When cleared
+        delete()
+
+        // Then it's back to null
+        assertThatNextEmissionIsEqualTo(null)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+  }
+
+  @Test
+  fun `Tag sort field`() = runTest {
+    before()
+    with(preferences.sortField) {
+      asFlow().test {
+        // Given the default sort field
+        assertThatNextEmissionIsEqualTo(TagSort.Field.Default)
+
+        // When a different field is stored
+        set(TagSort.Field.Usage)
+
+        // Then it round-trips
+        assertThatNextEmissionIsEqualTo(TagSort.Field.Usage)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+  }
+
+  @Test
+  fun `Tag sort direction`() = runTest {
+    before()
+    with(preferences.sortDirection) {
+      asFlow().test {
+        // Given the default sort direction
+        assertThatNextEmissionIsEqualTo(TagSort.Direction.Default)
+
+        // When a different direction is stored
+        set(TagSort.Direction.Descending)
+
+        // Then it round-trips
+        assertThatNextEmissionIsEqualTo(TagSort.Direction.Descending)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+  }
+}

--- a/aktual-prefs/impl/src/commonMain/kotlin/aktual/prefs/AppPreferencesImpl.kt
+++ b/aktual-prefs/impl/src/commonMain/kotlin/aktual/prefs/AppPreferencesImpl.kt
@@ -48,7 +48,4 @@ class AppPreferencesImpl(dataStore: DataStore<Preferences>) : AppPreferences {
         translator = stringListTranslator(),
       )
       .required()
-
-  override val lastUsedTagColor: NullablePreference<String> =
-    dataStore.string(key = stringPreferencesKey("lastUsedTagColor"), default = null)
 }

--- a/aktual-prefs/impl/src/commonMain/kotlin/aktual/prefs/TagPreferencesImpl.kt
+++ b/aktual-prefs/impl/src/commonMain/kotlin/aktual/prefs/TagPreferencesImpl.kt
@@ -1,0 +1,32 @@
+package aktual.prefs
+
+import aktual.budget.model.TagSort
+import aktual.di.AppScope
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import dev.zacsweers.metro.ContributesBinding
+
+@ContributesBinding(AppScope::class)
+class TagPreferencesImpl(dataStore: DataStore<Preferences>) : TagPreferences {
+  override val lastUsedTagColor: NullablePreference<String> =
+    dataStore.string(key = stringPreferencesKey("lastUsedTagColor"), default = null)
+
+  override val sortField: Preference<TagSort.Field> =
+    dataStore
+      .translated(
+        key = stringPreferencesKey("tagSortField"),
+        default = TagSort.Field.Default,
+        translator = enumStringTranslator(),
+      )
+      .required()
+
+  override val sortDirection: Preference<TagSort.Direction> =
+    dataStore
+      .translated(
+        key = stringPreferencesKey("tagSortDirection"),
+        default = TagSort.Direction.Default,
+        translator = enumStringTranslator(),
+      )
+      .required()
+}

--- a/aktual-prefs/src/commonMain/kotlin/aktual/prefs/AppPreferences.kt
+++ b/aktual-prefs/src/commonMain/kotlin/aktual/prefs/AppPreferences.kt
@@ -14,8 +14,4 @@ interface AppPreferences {
 
   // Ordered BudgetTab names for the nav grid; empty means "not customised"
   val navGridOrder: Preference<List<String>>
-
-  // The "#RRGGBB" colour last applied to a tag, used to seed the colour for the next new tag.
-  // Null until the user has saved a coloured tag
-  val lastUsedTagColor: NullablePreference<String>
 }

--- a/aktual-prefs/src/commonMain/kotlin/aktual/prefs/TagPreferences.kt
+++ b/aktual-prefs/src/commonMain/kotlin/aktual/prefs/TagPreferences.kt
@@ -1,0 +1,12 @@
+package aktual.prefs
+
+import aktual.budget.model.TagSort
+
+interface TagPreferences {
+  // The "#RRGGBB" colour last applied to a tag, used to seed the colour for the next new tag.
+  // Null until the user has saved a coloured tag
+  val lastUsedTagColor: NullablePreference<String>
+
+  val sortField: Preference<TagSort.Field>
+  val sortDirection: Preference<TagSort.Direction>
+}


### PR DESCRIPTION
Adds a sort dialog to the tags list screen — sort by name or number of transactions, ascending or descending. The choice is persisted (default: name ascending).

Also splits the tag-related preferences (last-used colour, sort field, sort direction) out of `AppPreferences` into a dedicated `TagPreferences`.