### PR TITLE
Add LeakCanary to Android debug builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Default new code to `commonMain`; reach for `androidMain` / `desktopMain` only w
 - **SDK**: min 28, target/compile 37.
 - **Desktop release** goes through Proguard — mapping at `aktual-app/desktop/build/outputs/mapping.txt`. Android goes through R8.
 - **SQLDelight** is pinned to a snapshot for KMP features; see `gradle/libs.versions.toml`.
+- **Android manifest lock**: `aktual-app/android` locks its merged manifest (`AndroidManifest.lock.yaml`) via the manifest-lock plugin with `failOnLockChange = true`, so adding/changing an Android dependency that touches the manifest (permissions, components) fails the build until the lock is regenerated. Run `./gradlew :aktual-app:android:androidManifestLock` to update it, then commit the change.
 
 ## Sub-CLAUDE.mds
 

--- a/aktual-app/android/build.gradle.kts
+++ b/aktual-app/android/build.gradle.kts
@@ -155,6 +155,7 @@ dependencies {
   implementation(libs.androidx.splash)
   implementation(libs.haze)
   implementation(libs.kotlinx.coroutines.core)
+  debugImplementation(libs.leakcanary)
   implementation(libs.logcat)
   implementation(libs.material)
   implementation(libs.metrox.android)

--- a/aktual-app/android/src/main/AndroidManifest.lock.yaml
+++ b/aktual-app/android/src/main/AndroidManifest.lock.yaml
@@ -41,9 +41,17 @@ variants:
   debug:
     namespace: dev.jonpoulton.aktual.app.dev
     permissions:
+    - android.permission.POST_NOTIFICATIONS
+    - android.permission.READ_EXTERNAL_STORAGE
+    - android.permission.WRITE_EXTERNAL_STORAGE
     - dev.jonpoulton.aktual.app.dev.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION
+    exports:
+      activity:
+      - leakcanary.internal.activity.LeakActivity
+      activity-alias:
+      - leakcanary.internal.activity.LeakLauncherActivity
   release:
     namespace: dev.jonpoulton.aktual.app
     permissions:
     - dev.jonpoulton.aktual.app.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION
-fingerprint: 37658cde6d3156ef32c3b03f56050bdd
+fingerprint: be3ea39f51dec81588ac87d1e940d43b

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-serialization-core = { module = "io.ktor:ktor-serialization", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-test = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version = "2.14" }
 logcat = { module = "com.squareup.logcat:logcat", version = "0.4" }
 markdown-core = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdown" }
 markdown-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdown" }


### PR DESCRIPTION
Adds LeakCanary to debug builds of the Android app for memory leak detection. It ships only in debug (`debugImplementation`) and auto-installs via its ContentProvider, so no `Application` wiring is needed. The debug manifest lock was regenerated to account for LeakCanary's injected components.

Closes #1387