### PR TITLE
Migrate Nucleus plugin to v2

### DIFF
--- a/aktual-app/desktop/build.gradle.kts
+++ b/aktual-app/desktop/build.gradle.kts
@@ -2,8 +2,8 @@
 
 import aktual.gradle.ConventionLicensee.Companion.LICENSEE_REPORT_ASSET_NAME
 import blueprint.core.gitVersionCode
-import io.github.kdroidfilter.nucleus.desktop.application.dsl.CompressionLevel
-import io.github.kdroidfilter.nucleus.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.desktop.application.dsl.CompressionLevel
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.Locale

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -145,7 +145,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 licensee = { id = "app.cash.licensee", version = "1.14.1" }
 manifestLock = { id = "io.github.gmazzo.android.manifest.lock", version = "1.4.0" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
-nucleus = { id = "io.github.kdroidfilter.nucleus", version = "1.15.7" }
+nucleus = { id = "dev.nucleusframework", version = "2.1.3" }
 redacted = { id = "dev.zacsweers.redacted", version.ref = "redacted" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 wire = { id = "com.squareup.wire", version = "6.4.5" }


### PR DESCRIPTION
Bumps the Nucleus desktop-packaging plugin from v1 (`io.github.kdroidfilter.nucleus` 1.15.7) to v2 (`dev.nucleusframework` 2.1.3).

v2 is a namespace rebrand: the plugin id, Maven coordinates and DSL package namespace all moved from `io.github.kdroidfilter.nucleus` to `dev.nucleusframework`. The `nucleus { ... }` DSL is otherwise unchanged, so this is limited to the plugin id/version and the two DSL imports.

Verified with `:aktual-app:desktop:compileAll` — configures and compiles cleanly.

Closes #1401