### PR TITLE
Apply straitjacket

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -213,7 +213,7 @@ jobs:
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-gradle
       - uses: ./.github/actions/setup-gradle-properties
-      - run: ./gradlew licensee androidManifestLock :aktual-core:l10n:catalog
+      - run: ./gradlew licensee androidManifestLock :aktual-core:l10n:catalog straitjacketCheck
       - run: ./scripts/unusedStrings.sh
 
   atlas:

--- a/.run/straitjacketCheck.run.xml
+++ b/.run/straitjacketCheck.run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="straitjacketCheck" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="straitjacketCheck" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
   compileOnlyPlugin(libs.plugins.kotlin.serialization)
   compileOnlyPlugin(libs.plugins.licensee)
   compileOnlyPlugin(libs.plugins.metro)
+  compileOnlyPlugin(libs.plugins.straitjacket)
 
   detektPlugins(libs.detektGradle)
 }

--- a/build-logic/src/main/kotlin/aktual/gradle/ConventionKotlinBase.kt
+++ b/build-logic/src/main/kotlin/aktual/gradle/ConventionKotlinBase.kt
@@ -17,6 +17,7 @@ class ConventionKotlinBase : Plugin<Project> {
       with(pluginManager) {
         apply(ConventionAtlas::class)
         apply(ConventionDi::class)
+        apply(ConventionStraitjacket::class)
       }
 
       extensions.configure(HasConfigurableKotlinCompilerOptions::class) {

--- a/build-logic/src/main/kotlin/aktual/gradle/ConventionStraitjacket.kt
+++ b/build-logic/src/main/kotlin/aktual/gradle/ConventionStraitjacket.kt
@@ -1,0 +1,19 @@
+package aktual.gradle
+
+import aktual.gradle.dsl.apply
+import aktual.gradle.dsl.configure
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import straitjacket.StraitjacketExtension
+import straitjacket.StraitjacketPlugin
+
+class ConventionStraitjacket : Plugin<Project> {
+  override fun apply(target: Project) =
+    with(target) {
+      pluginManager.apply(StraitjacketPlugin::class)
+
+      extensions.configure(StraitjacketExtension::class) {
+        // TBC
+      }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
   alias(libs.plugins.nucleus) apply false
   alias(libs.plugins.redacted) apply false
   alias(libs.plugins.sqldelight) apply false
+  alias(libs.plugins.straitjacket) apply false
   alias(libs.plugins.wire) apply false
 
   alias(libs.plugins.atlas)

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,3 +30,7 @@ org.gradle.tooling.parallel=true
 org.gradle.vfs.watch=true
 org.gradle.welcome=never
 org.gradle.workers.max=4
+
+straitjacket.enabled=true
+straitjacket.failOnViolation=true
+straitjacket.logForcedVersions=INFO

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -151,4 +151,5 @@ metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 nucleus = { id = "dev.nucleusframework", version = "2.1.5" }
 redacted = { id = "dev.zacsweers.redacted", version.ref = "redacted" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
+straitjacket = { id = "dev.jonpoulton.straitjacket", version = "0.1.0" }
 wire = { id = "com.squareup.wire", version = "6.4.5" }


### PR DESCRIPTION
Adds the [straitjacket](https://github.com/jonapoul/straitjacket) Gradle plugin, applied to all Kotlin modules via a new `ConventionStraitjacket` from `ConventionKotlinBase`. Config is empty for now.

CI runs `straitjacketCheck` as part of the existing `other-checks` job.